### PR TITLE
fix: design improvements

### DIFF
--- a/packages/ui5-cc-spreadsheetimporter/src/controller/Preview.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/Preview.ts
@@ -30,7 +30,7 @@ export default class Preview extends ManagedObject {
 			content: [table],
 			buttons: [
 				new Button({
-					text: "Close",
+					text: this.util.geti18nText("spreadsheetimporter.messageDialogButtonClose"),
 					press: () => {
 						this.dialog.close();
 					}

--- a/packages/ui5-cc-spreadsheetimporter/src/css/style.css
+++ b/packages/ui5-cc-spreadsheetimporter/src/css/style.css
@@ -7,6 +7,7 @@
 	flex-direction: column;
 	justify-content: center;
 	align-items: stretch;
+    margin: 10px 20px 10px 20px; /* top right bottom left */
 }
 
 .drag-over {

--- a/packages/ui5-cc-spreadsheetimporter/src/fragment/MessagesDialog.fragment.xml
+++ b/packages/ui5-cc-spreadsheetimporter/src/fragment/MessagesDialog.fragment.xml
@@ -6,13 +6,13 @@
       </MessageView>
     </content>
     <buttons>
-      <Button text="{i18n>spreadsheetimporter.downloadButton}" press="onDownloadErrors" />
       <Button
         press=".onContinue"
         type="Emphasized"
         text="{= ${info>/dialogState} === 'Error' ? ${i18n>spreadsheetimporter.messageDialogButtonContinueAnyway} : ${i18n>spreadsheetimporter.messageDialogButtonContinue} }"
         visible="{= !${info>/strict} &amp;&amp; !${info>/strictParameter}}"
       />
+      <Button text="{i18n>spreadsheetimporter.downloadButton}" press="onDownloadErrors" />
       <Button press=".onCloseMessageDialog" text="{i18n>spreadsheetimporter.messageDialogButtonClose}" />
     </buttons>
   </Dialog>

--- a/packages/ui5-cc-spreadsheetimporter/src/fragment/SpreadsheetUpload.fragment.xml
+++ b/packages/ui5-cc-spreadsheetimporter/src/fragment/SpreadsheetUpload.fragment.xml
@@ -4,13 +4,9 @@
       <OverflowToolbar>
         <Title text="{i18n>spreadsheetimporter.spreadsheetupload}" />
         <ToolbarSpacer />
-        <Button press="showPreview" text="{i18n>spreadsheetimporter.showPreview}" icon="sap-icon://display" visible="{= !${info>/hidePreview}}" />
-        <Button press="onTempDownload" text="{i18n>spreadsheetimporter.downloadTemplate}" icon="sap-icon://download-from-cloud" visible="{= !${info>/hideGenerateTemplateButton}}" />
-        <Button press="onOpenOptionsDialog" text="{i18n>spreadsheetimporter.showOptionMenu}" visible="{= ${info>/showOptions}}">
-          <layoutData>
-            <OverflowToolbarLayoutData priority="AlwaysOverflow" />
-          </layoutData>
-        </Button>
+        <Button press="showPreview" text="{i18n>spreadsheetimporter.showPreview}" visible="{= !${info>/hidePreview}}" enabled="{= ${info>/dataRows} > 0}" />
+        <Button press="onTempDownload" text="{i18n>spreadsheetimporter.downloadTemplate}" visible="{= !${info>/hideGenerateTemplateButton}}" />
+        <Button press="onOpenOptionsDialog" icon="sap-icon://action-settings" visible="{= ${info>/showOptions}}" />
       </OverflowToolbar>
     </spreadsheetdialog:customHeader>
     <spreadsheetdialog:content>

--- a/packages/ui5-cc-spreadsheetimporter/src/fragment/SpreadsheetUpload.fragment.xml
+++ b/packages/ui5-cc-spreadsheetimporter/src/fragment/SpreadsheetUpload.fragment.xml
@@ -21,7 +21,7 @@
         ],
         formatter: 'formatMessage'
       }"
-          type="{= ${info>/dataRows} > 0 ? 'Success' : 'None'}"
+          type="{= ${info>/dataRows} > 0 ? 'Success' : 'Information'}"
           enableFormattedText="true"
           showIcon="true"
         >

--- a/packages/ui5-cc-spreadsheetimporter/src/fragment/SpreadsheetUpload.fragment.xml
+++ b/packages/ui5-cc-spreadsheetimporter/src/fragment/SpreadsheetUpload.fragment.xml
@@ -1,5 +1,5 @@
 <core:FragmentDefinition xmlns="sap.m" xmlns:core="sap.ui.core" xmlns:upload="sap.ui.unified" xmlns:spreadsheetdialog="cc.spreadsheetimporter.XXXnamespaceXXX.control">
-  <spreadsheetdialog:SpreadsheetDialog contentWidth="{= ${device>/system/phone} ? '100%' : '40vw' }" contentHeight="150px" verticalScrolling="false">
+  <spreadsheetdialog:SpreadsheetDialog contentWidth="{= ${device>/system/phone} ? '100%' : '40vw' }" contentHeight="110px" verticalScrolling="false">
     <spreadsheetdialog:customHeader>
       <OverflowToolbar>
         <Title text="{i18n>spreadsheetimporter.spreadsheetupload}" />
@@ -10,11 +10,10 @@
       </OverflowToolbar>
     </spreadsheetdialog:customHeader>
     <spreadsheetdialog:content>
-      <FlexBox direction="Column" height="100%" width="80%" alignItems="Stretch" justifyContent="Center" fitContainer="true" class="centered">
+      <VBox>
         <MessageStrip
           xmlns:core="sap.ui.core"
           core:require="{ formatMessage: 'sap/base/strings/formatMessage' }"
-          visible="{= ${info>/dataRows} > 0}"
           text="{
         parts: [
           'i18n>spreadsheetimporter.dataRows',
@@ -22,7 +21,7 @@
         ],
         formatter: 'formatMessage'
       }"
-          type="Success"
+          type="{= ${info>/dataRows} > 0 ? 'Success' : 'None'}"
           enableFormattedText="true"
           showIcon="true"
         >
@@ -42,7 +41,7 @@
             <FlexItemData growFactor="5" styleClass="centeredFlex" />
           </upload:layoutData>
         </upload:FileUploader>
-      </FlexBox>
+      </VBox>
     </spreadsheetdialog:content>
     <spreadsheetdialog:buttons>
       <Button text="{i18n>spreadsheetimporter.upload}" press="onUploadSet" type="Emphasized" enabled="{= ${info>/dataRows} > 0}" />

--- a/packages/ui5-cc-spreadsheetimporter/src/i18n/i18n_de.properties
+++ b/packages/ui5-cc-spreadsheetimporter/src/i18n/i18n_de.properties
@@ -1,7 +1,7 @@
 # General
 spreadsheetimporter.compTitle=Spreadsheet Upload Control
 spreadsheetimporter.compDescription=Laden Sie Ihre Spreadsheet-Dateien hoch
-spreadsheetimporter.spreadsheetupload=Spreadsheet-Upload
+spreadsheetimporter.spreadsheetupload=Spreadsheet Upload
 
 # Spreadsheet Upload Dialog- Fragment
 spreadsheetimporter.spreadsheetuploadPlaceholder=Datei auswählen


### PR DESCRIPTION
fix #523 

## Changes

- remove icon from `Show Preview`and `Download Template`Button
- equal margin in Dialog Content for top and bottom content
- `Continue Anyway`Button to the left in Message Dialog
- `Options Button` only settings icon
- Message Strip always shown, initial state is `Information
- deactivate `Show Preview`Button when no data
- `Close` Button in Preview Dialog is translated now

### Initial State when opening

![image](https://github.com/spreadsheetimporter/ui5-cc-spreadsheetimporter/assets/13335743/47c74bf0-4836-43b5-b9b5-087325e213c3)


### After Upload

![image](https://github.com/spreadsheetimporter/ui5-cc-spreadsheetimporter/assets/13335743/895b8e5c-a3ed-4570-91d7-537b403f28de)

