### PR TITLE
fix: make `fireEventAsync` more stable

### DIFF
--- a/packages/ui5-cc-spreadsheetimporter/src/controller/Util.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/Util.ts
@@ -222,8 +222,12 @@ export default class Util extends ManagedObject {
 			event = eventPool.borrowObject(eventName, component, eventParameters); // borrow event lazily
 
 			for (let oInfo of aEventListeners) {
-				// Assuming each handler returns a promise
-				promises.push(oInfo.fFunction.call(null, event));
+				try {
+					// Assuming each handler returns a promise
+					promises.push(oInfo.fFunction.call(null, event));
+				} catch (error) {
+					Log.error("Error in event handler:", error as Error);
+				}
 			}
 		}
 
@@ -231,8 +235,8 @@ export default class Util extends ManagedObject {
 		await Promise.all(promises);
 
 		return {
-			bPreventDefault: (event as any).bPreventDefault,
-			mParameters: (event as any).mParameters,
+			bPreventDefault: (event as any)?.bPreventDefault,
+			mParameters: (event as any)?.mParameters,
 			returnValue: promises[0]
 		};
 	}


### PR DESCRIPTION
In some instances `event` does not return any paramater. In this case, return object of `fireEventAsync` should return undefined. Otherwise it would fail.