### PR TITLE
Fix when running spreadsheet importer in Fiori elements with multiple tabs

### DIFF
--- a/packages/ui5-cc-spreadsheetimporter/src/controller/dialog/SpreadsheetUploadDialog.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/dialog/SpreadsheetUploadDialog.ts
@@ -302,6 +302,7 @@ export default class SpreadsheetUploadDialog extends ManagedObject {
 	 * Closes the Spreadsheet upload dialog.
 	 */
 	onCloseDialog() {
+		this.component.fireRequestCompleted();
 		this.resetContent();
 		this.spreadsheetUploadDialog.close();
 	}


### PR DESCRIPTION
Hi @marianfoo ,
The upload dialog doesn't close correctly when using the cancel button. It disappears but still blocks the navigation in the fiori elements app. This fixes the problem.

Tested on version 1.96.32

Additional solution could be to provide an event handler to handle the cancel event ourself.

Kr, Wouter