### PR TITLE
feat: improve handling for unavailable UI5 APIs

### DIFF
--- a/packages/ui5-cc-spreadsheetimporter/src/controller/Util.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/Util.ts
@@ -182,16 +182,16 @@ export default class Util extends ManagedObject {
 	}
 
 	static async loadUI5RessourceAsync(moduleName: string): Promise<any> {
-		const alreadyLoadedLibrary = sap.ui.require(moduleName);
-		if (alreadyLoadedLibrary) {
-			return Promise.resolve(alreadyLoadedLibrary);
+		const alreadyLoadedModule = sap.ui.require(moduleName);
+		if (alreadyLoadedModule) {
+			return Promise.resolve(alreadyLoadedModule);
 		}
 
 		return new Promise(function (resolve, reject) {
 			sap.ui.require(
 				[moduleName],
-				function (Library: unknown) {
-					resolve(Library);
+				function (Module: unknown) {
+					resolve(Module);
 				},
 				function (err: any) {
 					reject(err);

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/Util.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/Util.ts
@@ -1,10 +1,10 @@
 import ManagedObject from "sap/ui/base/ManagedObject";
 import Log from "sap/base/Log";
-import ResourceBundle from "sap/base/i18n/ResourceBundle";
+import type ResourceBundle from "sap/base/i18n/ResourceBundle";
 import MessageBox from "sap/m/MessageBox";
-import { FireEventReturnType, RowData, ValueData } from "../types";
-import Component from "../Component";
-import { FieldMatchType } from "../enums";
+import type { FireEventReturnType, RowData, ValueData } from "../types";
+import type Component from "../Component";
+import type { FieldMatchType } from "../enums";
 import ObjectPool from "sap/ui/base/ObjectPool";
 import Event from "sap/ui/base/Event";
 import ts from "sap/ui/model/odata/v4/ts";
@@ -181,16 +181,21 @@ export default class Util extends ManagedObject {
 		URL.revokeObjectURL(url);
 	}
 
-	static async loadUI5RessourceAsync(libraryName: string): Promise<any> {
+	static async loadUI5RessourceAsync(moduleName: string): Promise<any> {
+		const alreadyLoadedLibrary = sap.ui.require(moduleName);
+		if (alreadyLoadedLibrary) {
+			return Promise.resolve(alreadyLoadedLibrary);
+		}
+
 		return new Promise(function (resolve, reject) {
 			sap.ui.require(
-				[libraryName],
+				[moduleName],
 				function (Library: unknown) {
 					resolve(Library);
 				},
 				function (err: any) {
 					reject(err);
-				}
+				},
 			);
 		});
 	}

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/dialog/ODataMessageHandler.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/dialog/ODataMessageHandler.ts
@@ -42,7 +42,7 @@ export default class ODataMessageHandler extends ManagedObject {
 		this.messageDialog.close();
 		// reset message manager messages
 		try {
-			// sap.ui.core.Messaging is only available in UI5 version 1.118 and above, prefer this over sap.ui.getCore().getMessageManager()saging = Util.loadUI5RessourceAsync("sap/ui/core/Messaging");
+			// sap.ui.core.Messaging is only available in UI5 version 1.118 and above, prefer this over sap.ui.getCore().getMessageManager() = Util.loadUI5RessourceAsync("sap/ui/core/Messaging");
 			const Messaging = await Util.loadUI5RessourceAsync("sap/ui/core/Messaging");
 			Messaging.removeAllMessages();
 			return;


### PR DESCRIPTION
Hey Marian,

found it interesting so I had a look/stab at it. Not sure what exactly you mean with "There is logic to check if library is availabe." in the original issue description. Maybe I'm overthinking it because I'm thinking about something like the UI5 linter where you know exactly what and if something is deprecated and needs replacing.

Nevertheless I implemented the 2nd part of the issue and took the liberty to rename `libraryName` to the (imo) more appropriate `moduleName`. Additionally I changed some imports to typed (if you need the full import for some transitive/bundling stuff, let me know). I removed some minor typo when I dug around a bit. 

---

### related notes (not necessary to read :P)

I was concerned about the mentioning of "sync" in the docs but I think it should be fine. Still I checked out the ui5loader and will  throw some refs/links here. Of course I wouldn't recommend using this stuff but ... good to know either way.

Accessing all loaded modules via ... well ... [_](https://github.com/SAP/openui5/blob/23ad1b401d0083af9002b46b5c11425c450d1d75/src/sap.ui.core/src/ui5loader.js#L2690-L2904)
```js
sap.ui.loader._.*(getAllModules())
```
- [mModules](https://github.com/SAP/openui5/blob/23ad1b401d0083af9002b46b5c11425c450d1d75/src/sap.ui.core/src/ui5loader.js#L304) (internal state)
- [actual impl](https://github.com/SAP/openui5/blob/23ad1b401d0083af9002b46b5c11425c450d1d75/src/sap.ui.core/src/ui5loader.js#L2152). behind require 

Found similar implementations (with some hints in regards to full Promise support (some time in the future). Regardless I found it confirming for the probing approach (mentioned by you & the docs + promise support). Not that I was against it or didn't know about it, I'm just always unsure and try to double/triple check, so here we are. :P 

- [Example impl.](https://github.com/SAP/openui5/blob/23ad1b401d0083af9002b46b5c11425c450d1d75/src/sap.ui.fl/src/sap/ui/fl/requireAsync.js#L22-L39) `requireAsync`

In regards to figuring out the deprecations ... that's a hard one. At first I thought maybe [Metadata](https://github.com/SAP/openui5/blob/23ad1b401d0083af9002b46b5c11425c450d1d75/src/sap.ui.core/src/sap/ui/base/Metadata.js#L402-L411) could help. But then I thought about it and in the case of e.g. `sap.ui.getCore().getMessageManager()` the returned object itself wouldn't have the Metadata attached and additionally the case here wouldn't be that the class itself used behind this facade is deprecated but rather the way it is accessed.

I guess one could have a look at the UI5Linter and how it is handled/implemented there. But I guess that is a bit too much effort for a few fallbacks in your project for now. Maybe the UI5Linter could be used later on or have an API exposed to help with these programmatic use-cases or .. you know ... get into the trenches like Peter did and play around with some ASTs and AST manipulation or maintain some sort of deprecations + simple replacements yourself and apply them as needed ... think thats going too far tho(?)^^