### PR TITLE
feat: add deep download option into component

### DIFF
--- a/.github/workflows/wdi5-test.yml
+++ b/.github/workflows/wdi5-test.yml
@@ -23,7 +23,7 @@ jobs:
             ui5version: 84
           - scenario: ordersv4freestyle
             ui5version: 96
-            - scenario: ordersv4freestyle
+          - scenario: ordersv4freestyle
             ui5version: 108
 
     steps:

--- a/.github/workflows/wdi5-test.yml
+++ b/.github/workflows/wdi5-test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scenario: ["ordersv2fe", "ordersv4fe", "ordersv2fenondraft", "ordersv2freestylenondraftopenui5", "ordersv2freestylenondraft"]
+        scenario: ["ordersv2fe", "ordersv4fe", "ordersv2fenondraft", "ordersv2freestylenondraftopenui5", "ordersv2freestylenondraft", "ordersv4freestyle"]
         ui5version: [120, 108, 96, 84, 71] # 120 as soon as wdi5 issue is fixed
         exclude:
           - scenario: ordersv4fe

--- a/.github/workflows/wdi5-test.yml
+++ b/.github/workflows/wdi5-test.yml
@@ -17,12 +17,14 @@ jobs:
         exclude:
           - scenario: ordersv4fe
             ui5version: 71
-          # - scenario: ordersv4fets
-          #   ui5version: 71
-          # - scenario: ordersv4fets
-          #   ui5version: 84
-          # - scenario: ordersv4fets
-          #   ui5version: 96
+          - scenario: ordersv4freestyle
+            ui5version: 71
+          - scenario: ordersv4freestyle
+            ui5version: 84
+          - scenario: ordersv4freestyle
+            ui5version: 96
+            - scenario: ordersv4freestyle
+            ui5version: 108
 
     steps:
       # - name: update chrome

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ package-lock.json
 packages/ui5-cc-spreadsheetimporter/webapp
 dev/thirdparty
 .ui5-tooling-modules
+examples/test/downloads
 # test apps start
 /examples/packages/ordersv2fe108
 /examples/packages/ordersv2fe96

--- a/dev/replace-string.js
+++ b/dev/replace-string.js
@@ -30,6 +30,6 @@ util.updateManifestVersion(version)
 updateVersionDocs.updateVersions(versionUnderscore)
 
 if (!develop) {
-	let ui5Apps = ["ordersv2fe", "ordersv2fenondraft", "ordersv2freestylenondraft", "ordersv2freestylenondraftopenui5", "ordersv4fe", "ordersv4fpm", "ordersv4fets", "anyupload"];
+	let ui5Apps = ["ordersv2fe", "ordersv2fenondraft", "ordersv2freestylenondraft", "ordersv2freestylenondraftopenui5", "ordersv4fe", "ordersv4fpm", "ordersv4fets", "anyupload", "ordersv4freestyle"];
 	util.replaceVersionInExamples(versionUnderscore, versionUnderscore, ui5Apps);
 }

--- a/dev/testapps.json
+++ b/dev/testapps.json
@@ -312,6 +312,20 @@
     "copyVersions": []
   },
   {
+    "rootAppName": "ordersv4freestyle",
+    "id": "uordersv4freestyle",
+    "path": "./examples/packages/",
+    "port": "8190",
+    "versionMinor": 120,
+    "appTitel": "Orders V4 FS 120",
+    "testMapping": {
+      "specs": [
+        "../test/specs/download/**.test.js"
+      ]
+    },
+    "copyVersions": []
+  },
+  {
     "rootAppName": "ordersv4fpm",
     "port": "8084",
     "versionMinor": 120,

--- a/docs/pages/Button.md
+++ b/docs/pages/Button.md
@@ -99,8 +99,7 @@ settings="{
   columns: ['product_ID', 'username'],
   componentContainerData:{
     uploadButtonPress:'uploadButtonPress',
-    buttonText:'Excel Upload',
-    downloadButton:true
+    buttonText:'Excel Upload'
     }
   }" />
 ```

--- a/docs/pages/Button.md
+++ b/docs/pages/Button.md
@@ -99,7 +99,8 @@ settings="{
   columns: ['product_ID', 'username'],
   componentContainerData:{
     uploadButtonPress:'uploadButtonPress',
-    buttonText:'Excel Upload'
+    buttonText:'Excel Upload',
+    downloadButton:true
     }
   }" />
 ```

--- a/docs/pages/Configuration.md
+++ b/docs/pages/Configuration.md
@@ -491,6 +491,7 @@ For the event, the method from your view controller is attached to the event.
 | Option | Description | Details |
 | ------ | --- | --- |
 | `buttonText` | Text to be displayed on the button | string |
+| `buttonId` | Id of the button | string |
 | `downloadButton` | Defines whether the download event should be triggered instead of the upload event | boolean |
 | `uploadButtonPress` | Event after the upload button is pressed | string |
 | `changeBeforeCreate` | Event before data sent to the backend | string |

--- a/docs/pages/Configuration.md
+++ b/docs/pages/Configuration.md
@@ -25,6 +25,7 @@ The table below summarizes the options available for the UI5 Spreadsheet Importe
 | [`previewColumns`](#previewcolumns)                 | Specifies columns to display in the preview dialog.   | `[]`    | `string[]` |
 | [`showBackendErrorMessages`](#showbackenderrormessages)| Displays backend error messages in the UI.          | `false` | `boolean`  |
 | [`showOptions`](#showoptions)                       | Shows a menu to change configurations at runtime.     | `false` | `boolean`  |
+| [`showDownloadButton`](#showdownloadbutton)         | Shows the button to download the uploaded data.       | `false` | `boolean`  |
 
 ### Data Processing Options
 
@@ -360,7 +361,12 @@ There are also only a few selected configurations available.
 
 ### `availableOptions`
 
-**default:** `[]`
+### `showDownloadButton`
+
+**default:** `false`
+
+This option defines whether the button to download data should be displayed or not.  
+More information can be found in the [Spreadsheet Deep Download](spreadsheetdownload.md) documentation.
 
 #### Available Options
 

--- a/docs/pages/Configuration.md
+++ b/docs/pages/Configuration.md
@@ -491,6 +491,7 @@ For the event, the method from your view controller is attached to the event.
 | Option | Description | Details |
 | ------ | --- | --- |
 | `buttonText` | Text to be displayed on the button | string |
+| `downloadButton` | Defines whether the download event should be triggered instead of the upload event | boolean |
 | `uploadButtonPress` | Event after the upload button is pressed | string |
 | `changeBeforeCreate` | Event before data sent to the backend | string |
 | `checkBeforeRead` | Event before data is uploaded to the app | string |
@@ -505,9 +506,22 @@ usage="spreadsheetImporter" propagateModel="true" async="true"
 settings="{
   standalone:true,
   columns: ['product_ID', 'username'],
+  deepDownloadConfig:{
+    deepLevel: 2,
+    deepExport: true,
+    addKeysToExport: true,
+    showOptions: true,
+    filename: 'Orders12',
+    columns : {
+        'OrderNo':{
+            'order': 1
+        }
+    }
+  },
   componentContainerData:{
     uploadButtonPress:'uploadButtonPress',
-    buttonText:'Excel Upload'
+    buttonText:'Excel Upload',
+    downloadButton:true
     }
   }" />
 ````

--- a/docs/pages/Development/SpreadsheetDownload.md
+++ b/docs/pages/Development/SpreadsheetDownload.md
@@ -1,0 +1,218 @@
+This feature is experimental and only available with a OData V4 backend.
+
+## Triggering the download
+
+The spreadsheet download is triggered by a button in the spreadsheet upload dialog.
+
+This will run onInitDownloadSpreadsheetProcess in SpreadsheetUploadDialog.ts.  
+If config.showOptions is true, the SpreadsheetDownloadDialog will be created and opened. With this dialog it is possible to set options as a user.
+From the SpreadsheetDownloadDialog the method onSave is triggered, which sets the deepDownloadConfig and then calls onDownloadDataSpreadsheet.
+
+If config.showOptions is false, the SpreadsheetDownload will be triggered directly with the default or developer defined options.
+
+## Method onDownloadDataSpreadsheet
+
+The method first checks if there are any errors. Errors can occur in the setContext method of SpreadsheetUpload.ts.
+
+## MetadataHandlerV4
+
+In the MetadataHandler the code builds the metadata model, which is a tree of all the entities and their properties.  
+Here the entityName should be the root entity of the download and deepLevel should be the maximum depth of the download.
+
+From the rootEntity the method _findEntitiesByNavigationProperty is called. This method traverses the metadata model and collects all the entities that are related to the rootEntity by navigation properties.  
+If the `$kind` and `$Partner` properties are present and the `$ReferentialConstraint` is not, the full entity is added to the parent entity (or root entity) as property name `$XYZEntity` and making it explicitly fetchable with `$XYZFetchableEntity` property.
+
+In this example to the entity `OrdersService.Order` the entity `OrdersService.OrderItems` is added as `$XYZEntity` and `$XYZFetchableEntity` is set to true.
+
+This is the root entity without some properties for brevity before the navigation property was added:
+
+```json
+{
+    "$kind": "EntityType",
+    "$Key": [
+        "ID",
+        "IsActiveEntity"
+    ],
+    "OrderNo": {
+        "$kind": "Property",
+        "$Type": "Edm.String",
+        "$MaxLength": 22
+    },
+    "Items": {
+        "$kind": "NavigationProperty",
+        "$isCollection": true,
+        "$Type": "OrdersService.OrderItems",
+        "$Partner": "order",
+        "$OnDelete": "Cascade"
+    },
+    "Shipping": {
+        "$kind": "NavigationProperty",
+        "$isCollection": true,
+        "$Type": "OrdersService.ShippingDetails",
+        "$Partner": "order",
+        "$OnDelete": "Cascade"
+    },
+    "buyer": {
+        "$kind": "Property",
+        "$Type": "Edm.String",
+        "$MaxLength": 255
+    }
+}
+```
+
+This is the root entity after navigation properties for `Items` (here `Infos` under `Items`) and `Shipping` were added:
+
+```json
+{
+    "$kind": "EntityType",
+    "$Key": [
+        "ID",
+        "IsActiveEntity"
+    ],
+    "ID": {
+        "$kind": "Property",
+        "$Type": "Edm.Guid",
+        "$Nullable": false
+    },
+    "OrderNo": {
+        "$kind": "Property",
+        "$Type": "Edm.String",
+        "$MaxLength": 22
+    },
+    "Items": {
+        "$kind": "NavigationProperty",
+        "$isCollection": true,
+        "$Type": "OrdersService.OrderItems",
+        "$Partner": "order",
+        "$OnDelete": "Cascade",
+        "$XYZEntity": {
+            "$kind": "EntityType",
+            "$Key": [
+                "ID",
+                "IsActiveEntity"
+            ],
+            "ID": {
+                "$kind": "Property",
+                "$Type": "Edm.Guid",
+                "$Nullable": false
+            },
+            "order": {
+                "$kind": "NavigationProperty",
+                "$Type": "OrdersService.Orders",
+                "$Partner": "Items",
+                "$ReferentialConstraint": {
+                    "order_ID": "ID"
+                }
+            },
+            "order_ID": {
+                "$kind": "Property",
+                "$Type": "Edm.Guid"
+            },
+            "product_ID": {
+                "$kind": "Property",
+                "$Type": "Edm.String"
+            },
+            "Infos": {
+                "$kind": "NavigationProperty",
+                "$isCollection": true,
+                "$Type": "OrdersService.OrderItemsInfo",
+                "$Partner": "orderItem",
+                "$OnDelete": "Cascade",
+                "$XYZEntity": {
+                    "$kind": "EntityType",
+                    "$Key": [
+                        "ID",
+                        "IsActiveEntity"
+                    ],
+                    "ID": {
+                        "$kind": "Property",
+                        "$Type": "Edm.Guid",
+                        "$Nullable": false
+                    },
+                    "orderItem": {
+                        "$kind": "NavigationProperty",
+                        "$Type": "OrdersService.OrderItems",
+                        "$Partner": "Infos",
+                        "$ReferentialConstraint": {
+                            "orderItem_ID": "ID"
+                        }
+                    },
+                    "orderItem_ID": {
+                        "$kind": "Property",
+                        "$Type": "Edm.Guid"
+                    },
+                    "comment": {
+                        "$kind": "Property",
+                        "$Type": "Edm.String"
+                    }
+                },
+                "$XYZFetchableEntity": true
+            },
+            "quantity": {
+                "$kind": "Property",
+                "$Type": "Edm.Int32"
+            }
+        },
+        "$XYZFetchableEntity": true
+    },
+    "Shipping": {
+        "$kind": "NavigationProperty",
+        "$isCollection": true,
+        "$Type": "OrdersService.ShippingDetails",
+        "$Partner": "order",
+        "$OnDelete": "Cascade",
+        "$XYZEntity": {
+            "$kind": "EntityType",
+            "$Key": [
+                "ID",
+                "IsActiveEntity"
+            ],
+            "ID": {
+                "$kind": "Property",
+                "$Type": "Edm.Guid",
+                "$Nullable": false
+            },
+            "order": {
+                "$kind": "NavigationProperty",
+                "$Type": "OrdersService.Orders",
+                "$Partner": "Shipping",
+                "$ReferentialConstraint": {
+                    "order_ID": "ID"
+                }
+            },
+            "order_ID": {
+                "$kind": "Property",
+                "$Type": "Edm.Guid"
+            }
+        },
+        "$XYZFetchableEntity": true
+    },
+    "buyer": {
+        "$kind": "Property",
+        "$Type": "Edm.String",
+        "$MaxLength": 255
+    }
+}
+```
+
+With this metadata model it is much easier to fetch data and have a overview of all the entities that are related to the root entity.
+
+### Expands
+
+In the next step the method _getExpandsRecursive is called. This method traverses the metadata model and creates a list of expands for the Odata Binding which is created in getBindingFromBinding in ODataV4.ts.  
+The expands are used to fetch the related entities in one request.
+
+### Binding
+
+With the binding from the root entity a custom binding is created with the expands in getBindingFromBinding in ODataV4.ts to fetch the data.
+
+### fetchBatch
+
+The method fetchBatch in ODataV4.ts is used to fetch the data in batches of 1000. This is done to prevent the OData V4 backend from timing out.  
+This is done inside the current context and might be failing on memory issues.  
+The data is requested with `requestContexts` from the binding and the results are of type `sap.ui.model.odata.v4.Context[]`and returned in the variable `totalResults`.
+
+### extractObjects Method
+
+The variable `totalResults` is then processed with the method `extractObjects` in Util.ts. This method converts the `sap.ui.model.odata.v4.Context` to the requested object with requesting `getObject` from the binding. With this method the data is converted to an array of objects.
+

--- a/docs/pages/Events.md
+++ b/docs/pages/Events.md
@@ -7,10 +7,13 @@ The following events can be used as extension points to intervene and manipulate
 | `changeBeforeCreate` | Change data before it is sent to the backend                                                       |
 | `requestCompleted`   | Event when the request is completed                                                                |
 | `uploadButtonPress`  | Fired when the `Upload` button is pressed, possible to prevent data from being sent to the backend |
+| `beforeDownloadFileProcessing`  | Fired before the data is converted to a spreadsheet file |
+| `beforeDownloadFileExport`      | Fired just before the file is downloaded                                                  |
+
 
 You can attach async functions to the events by wrapping the function in a `Promise`. See [Attach async functions to events](#attach-async-functions-to-events) for more information.
 
-## Execute custom logic before processing the spreadsheet file starts
+## Event `preFileProcessing`
 
 When the file is uploaded to the app, the `preFileProcessing` event is fired. Use this event to execute custom logic before processing the spreadsheet file starts.
 The `file` is available in the event and can be manipulated. If you want to prevent the processing of the file, call the `preventDefault` method of the event. If you want to change the file that will be processed, return the new file.
@@ -36,7 +39,7 @@ if (file.name.endsWith(".txt")) {
 });
 ```
 
-## Check data before upload to app
+## Event `checkBeforeRead`
 
 When the file is uploaded to the app, the `checkBeforeRead` event is fired.
 
@@ -80,7 +83,7 @@ Errors with the same title will be grouped.
 
 ![Error Dialog](./../images/error_dialog.png){ loading=lazy }
 
-## Manipulate data before it is sent to the backend
+## Event `changeBeforeCreate`
 
 When the `Upload` button is pressed, the `changeBeforeCreate` event is fired.  Use this event to manipulate the data before it is sent to the backend. The event expects a payload object to be returned.  
 Make sure only one handler is attached to this event. If multiple handlers are attached, only the first payload will be used.
@@ -100,7 +103,7 @@ this.spreadsheetUpload.attachChangeBeforeCreate(function (event) {
 }, this);
 ```
 
-## Event when the request is completed
+## Event `requestCompleted`
 
 When the request is completed, the `requestCompleted` event is fired. Use the `success` parameter to check if the request was successful.
 
@@ -117,7 +120,7 @@ this.spreadsheetUpload.attachRequestCompleted(function (event) {
 }, this);
 ```
 
-## Event when the upload button is pressed
+## Event `uploadButtonPress`
 
 When the `Upload` button is pressed, the `uploadButtonPress` event is fired. The event is fired before the `changeBeforeCreate` event. Prevent the data from being sent to the backend by calling the `preventDefault` method of the event.
 
@@ -157,6 +160,61 @@ this.spreadsheetUpload.attachUploadButtonPress(async function (event) {
     // Code here will execute after the 2-second wait
 }, this);
 ```
+
+## Event `beforeDownloadFileProcessing`
+
+Parameters:  
+
+- `data`- the data that will be converted to a spreadsheet file, the data is always the `$XYZData` property of the data object
+
+This event is fired before the data is converted to a spreadsheet file. Use this event to manipulate the data before it is converted.  
+You can change directly the data parameter of the event as this is a reference to the data.
+
+### Example
+
+```javascript
+onDownload: async function () {
+    // init your spreadsheet upload component
+    this.spreadsheetUpload.attachBeforeDownloadFileProcessing(this.onBeforeDownloadFileProcessing, this);
+    this.spreadsheetUpload.triggerDownloadSpreadsheet();
+},
+
+onBeforeDownloadFileProcessing: function (event) {
+    const data = event.getParameters().data;
+    // change buyer of first row of the root entity
+    data.$XYZData[0].buyer = "Customer 123";
+    // change quantity of first row of the Items entity
+    data.Items.$XYZData[0].quantity = 4
+}
+```
+
+## Event `beforeDownloadFileExport`
+
+Parameters:
+
+- `workbook` - the SheetJS [workbook object](https://docs.sheetjs.com/docs/csf/book)
+- `filename` - the filename of the file that will be downloaded
+
+This event is fired just before the file is downloaded. Use this event to manipulate the filename or other parameters before the file is downloaded.
+
+
+
+### Example
+
+```javascript
+onDownload: async function () {
+    // init your spreadsheet upload component
+    this.spreadsheetUpload.attachBeforeDownloadFileExport(this.onBeforeDownloadFileExport, this);
+    this.spreadsheetUpload.triggerDownloadSpreadsheet();
+},
+
+onBeforeDownloadFileExport: function (event) {
+
+    const workbook = event.getParameters().workbook;
+    event.getParameters().filename = filename + "_modified";
+}
+```
+
 
 ## Attach async functions to events
 

--- a/docs/pages/GettingStarted.md
+++ b/docs/pages/GettingStarted.md
@@ -35,8 +35,8 @@ To integrate the `ui5-cc-spreadsheetimporter` component manually, follow the ste
 
 2\. **Add `resourceRoots` to the `sap.ui5` section of your `manifest.json`:**
 
-   !!! warning "Version Management"
-       Whenever you update the `ui5-cc-spreadsheetimporter` module, ensure that the version specified in your `manifest.json` is up to date. For more information, see [Version Namespace](https://blogs.sap.com/2023/03/12/create-a-ui5-custom-library-with-versioning-using-a-multi-version-namespace/).
+!!! warning "Version Management"
+    Whenever you update the `ui5-cc-spreadsheetimporter` module, ensure that the version specified in your `manifest.json` is up to date. For more information, see [Version Namespace](https://blogs.sap.com/2023/03/12/create-a-ui5-custom-library-with-versioning-using-a-multi-version-namespace/).
 
    ```json
    "resourceRoots": {
@@ -54,8 +54,8 @@ To integrate the `ui5-cc-spreadsheetimporter` component manually, follow the ste
 
 4\. **Add `componentUsages` to the `sap.ui5` section of your `manifest.json`:**
 
-   !!! warning "Version Management"
-       Whenever you update the `ui5-cc-spreadsheetimporter` module, ensure that the version specified in your `manifest.json` is up to date. For more information, see [Version Namespace](https://blogs.sap.com/2023/03/12/create-a-ui5-custom-library-with-versioning-using-a-multi-version-namespace/).
+!!! warning "Version Management"
+    Whenever you update the `ui5-cc-spreadsheetimporter` module, ensure that the version specified in your `manifest.json` is up to date. For more information, see [Version Namespace](https://blogs.sap.com/2023/03/12/create-a-ui5-custom-library-with-versioning-using-a-multi-version-namespace/).
 
    ```json
    "componentUsages": {

--- a/docs/pages/spreadsheetdownload.md
+++ b/docs/pages/spreadsheetdownload.md
@@ -91,7 +91,7 @@ componentData: {
 
 This option defines the columns to export.  
 By default, all columns are exported.
-It is possible to define the order of the columns by using the `order` property but only for the flat structure.
+It is possible to define the order of the columns by using the `order` property.
 To know which columns are available, it is possible to turn on `debug` as an option.
 With this option, the `mainEntity` is logged and then you can use it as a reference.
 
@@ -124,12 +124,6 @@ This option defines how deep sibling entities should be exported.
 **default:** `true`
 
 This option determines whether the options dialog should be shown to the user.
-
-### flatSheet
-
-**default:** `false`
-
-This option determines whether the data should be exported in a flat structure.
 
 
 ## API

--- a/docs/pages/spreadsheetdownload.md
+++ b/docs/pages/spreadsheetdownload.md
@@ -1,5 +1,9 @@
 # Spreadsheet Deep Download
 
+!!! warning
+    This new feature is experimental and may change in the future and currently only available for OData V4.
+    If you deep download data, the OData Service need to support `expand`.
+
 This feature downloads data from the backend and converts it to a Spreadsheet file. In the future, the feature will allow users to upload data in order to update the data in the backend.
 
 The main difference between this feature and the integrated Spreadsheet Download is that it can download data from multiple entities at once.

--- a/docs/pages/spreadsheetdownload.md
+++ b/docs/pages/spreadsheetdownload.md
@@ -4,56 +4,37 @@
     This new feature is experimental and may change in the future and currently only available for OData V4.
     If you deep download data, the OData Service need to support `expand`.
 
-This feature downloads data from the backend and converts it to a Spreadsheet file. In the future, the feature will allow users to upload data in order to update the data in the backend.
+This feature downloads data from the backend and converts it to a Spreadsheet file.
 
-The main difference between this feature and the integrated Spreadsheet Download is that it can download data from multiple entities at once.
+The main difference between this feature and the integrated Spreadsheet Download is that it can download data from multiple sub-entities at once.
 
-For example, if you have Orders and OrderItems, you can download both entities at once and the data will be structured in the Spreadsheet file in a way that allows for easy data updates and re-uploading. It is also possible to recursively download data from multiple entities indefinitely.
+For example, if you have Orders and OrderItems, you can download both entities at once and the data will be structured in the Spreadsheet. It is also possible to recursively download data from multiple entities indefinitely.
 
 - Orders
     - OrderItems
         - Info
     - ShippingInfos
 
-This means that you can download all Orders, including the OrderItems, ShippingInfos, and the Info of the OrderItems.
-
-## Technical Details
-
-The download process involves several key components:
-
-1. **Data Fetching**: The system fetches data recursively based on the configured deep level with expands, handling batch processing for large datasets.
-
-2. **Data Assignment**: The DataAssigner handles:
-   - Root entity data assignment
-   - Column assignments
-   - Recursive data assignment for nested entities
-   - Handling of fetchable entities
-
-3. **Spreadsheet Generation**: The SpreadsheetGenerator creates:
-   - Multiple sheets for different entities
-   - Proper column formatting based on data types
-   - Sheet naming with collision handling
-   - Column width optimization
+This means that you can download all Orders, including the OrderItems, ShippingInfos, and the Info of the OrderItems in one go.
 
 ## Configuration
 
 | Option | Description | Default | Type |
 | ------ | ----------- | ------- | ---- |
-| `addKeysToExport` | Adds hidden keys to the export | `false` | boolean |
-| `filename` | Defines the filename for the export XLSX file | Entity Name | string |
-| `deepExport` | Also exports sibling entities | `false` | boolean |
-| `deepLevel` | Defines the level of sibling entities to export | `1` | number |
-| `showOptions` | Shows options dialog for users | `true` | boolean |
+| `addKeysToExport` | Adds keys to the export file | `false` | boolean |
+| `filename` | Defines the filename for the export  file | Entity Name | string |
+| `deepExport` | Turn on to export of sibling entities | `false` | boolean |
+| `deepLevel` | Defines the level of sibling entities to export | `0` | number |
+| `showOptions` | Shows options dialog for users | `false` | boolean |
 | `columns` | Defines the columns to export | `{}` | object |
 
 ### Sample Usage
 
-The configuration is done in the `pro` section of the component data:
+The configuration is done in the `deepDownloadConfig` section of the component data:
 
 ```json
 componentData: {
     context: this,
-    activateDraft: true,
     showDownloadButton: true,
     deepDownloadConfig: {
         deepLevel: 1,
@@ -91,7 +72,7 @@ componentData: {
 
 This option defines the columns to export.  
 By default, all columns are exported.
-It is possible to define the order of the columns by using the `order` property.
+It is possible to define the order of the columns by using the `order` property.  
 To know which columns are available, it is possible to turn on `debug` as an option.
 With this option, the `mainEntity` is logged and then you can use it as a reference.
 
@@ -99,7 +80,7 @@ With this option, the `mainEntity` is logged and then you can use it as a refere
 
 **default:** `false`
 
-This option adds hidden keys to the export, such as GUIDs that are usually hidden in the UI. These keys are necessary for updating data from the file in the future.
+This option adds keys (which can be hidden in the UI) to the export, such as GUIDs.
 
 ### filename
 
@@ -115,7 +96,7 @@ This option determines whether sibling entities should be exported as well.
 
 ### deepLevel
 
-**default:** `1`
+**default:** `0`
 
 This option defines how deep sibling entities should be exported.
 
@@ -160,3 +141,71 @@ download: async function () {
     });
 }
 ```
+
+## Download Button
+
+Same as the [Button control](./Button.md), the Download Button can be used to trigger the Spreadsheet Download directly in the XML View.  
+A sample usage can be found [here](https://github.com/spreadsheetimporter/ui5-cc-spreadsheetimporter/tree/main/examples/packages/ordersv4freestyle).  
+For the configuration options, see [Button](./Configuration.md#componentcontainerdata).
+
+A usage can look like this:
+
+```xml
+<mvc:View controllerName="ordersv4freestyle.controller.MainView"
+    xmlns:mvc="sap.ui.core.mvc" xmlns:core="sap.ui.core" displayBlock="true"
+    xmlns="sap.m">
+    <Page id="page" title="{i18n>title}">
+        <content>
+            <VBox>
+                <core:ComponentContainer
+                    id="test"
+                    width="100%"
+                    usage="spreadsheetImporter"
+                    propagateModel="true"
+                    async="true"
+                    settings="{
+                    componentContainerData:{uploadButtonPress:'uploadButtonPress',buttonText:'Excel Download',buttonId:'downloadButton',downloadButton:true},
+                    deepDownloadConfig:{
+                        deepLevel: 0,
+                        deepExport: false,
+                        addKeysToExport: true,
+                        showOptions: false,
+                        filename: 'Orders12',
+                        columns : {
+                            'OrderNo':{
+                                'order': 1
+                        }
+                      }
+                    }
+                  }"
+                />
+                <Button id="downloadButtonCode" text="Excel Download Code" press="onDownload"/>
+                <Table id="ordersTable" items="{/Orders}">
+                    <columns>
+                        <Column>
+                            <Text text="Order Number"/>
+                        </Column>
+                        <Column>
+                            <Text text="Buyer"/>
+                        </Column>
+                        <Column>
+                            <Text text="Created At"/>
+                        </Column>
+                    </columns>
+                    <items>
+                        <ColumnListItem>
+                            <cells>
+                                <Text text="{OrderNo}"/>
+                                <Text text="{buyer}"/>
+                                <Text text="{createdAt}"/>
+                            </cells>
+                        </ColumnListItem>
+                    </items>
+                </Table>
+            </VBox>
+        </content>
+    </Page>
+</mvc:View>
+
+```
+

--- a/docs/pages/spreadsheetdownload.md
+++ b/docs/pages/spreadsheetdownload.md
@@ -21,6 +21,7 @@ This means that you can download all Orders, including the OrderItems, ShippingI
 | `deepExport` | Also exports sibling entities | object |
 | `deepLevel` | Defines the level of sibling entities to export | object |
 | `showOptions` | Shows options dialog for users to change configurations | object |
+| `columns` | Defines the columns to export | object |
 
 ### Sample Usage
 
@@ -92,12 +93,10 @@ download: async function () {
             componentData: {
                 context: this,
                 activateDraft: true,
-                pro: {
-                    spreadsheetExportConfig: {
-                        deepLevel: 1,
-                        deepExport: true,
-                        addKeysToExport: true
-                    }
+                deepDownloadConfig: {
+                    deepLevel: 1,
+                    deepExport: true,
+                    addKeysToExport: true
                 }
             }
         });

--- a/docs/pages/spreadsheetdownload.md
+++ b/docs/pages/spreadsheetdownload.md
@@ -50,16 +50,46 @@ The configuration is done in the `pro` section of the component data:
 componentData: {
     context: this,
     activateDraft: true,
-    pro: {
-        spreadsheetExportConfig: {
-            deepLevel: 2,
-            deepExport: true,
-            addKeysToExport: true,
-            filename: 'MyExport'
+    showDownloadButton: true,
+    deepDownloadConfig: {
+        deepLevel: 1,
+        deepExport: false,
+        addKeysToExport: false,
+        showOptions: false,
+        columns : {
+            "OrderNo":{
+                "order": 1
+            },
+            "buyer": {
+                "order": 3
+            },
+            "Items": {
+                "quantity" : {
+                    "order": 2
+                },
+                "title": {
+                    "order": 4
+                }
+            },
+            "Shipping": {
+                "address" : {
+                    "order": 5
+                },
+            }
         }
     }
 }
 ```
+
+### columns
+
+**default:** `{}`
+
+This option defines the columns to export.  
+By default, all columns are exported.
+It is possible to define the order of the columns by using the `order` property but only for the flat structure.
+To know which columns are available, it is possible to turn on `debug` as an option.
+With this option, the `mainEntity` is logged and then you can use it as a reference.
 
 ### addKeysToExport
 
@@ -91,14 +121,20 @@ This option defines how deep sibling entities should be exported.
 
 This option determines whether the options dialog should be shown to the user.
 
+### flatSheet
+
+**default:** `false`
+
+This option determines whether the data should be exported in a flat structure.
+
 
 ## API
 
-### triggerSpreadsheetDownload
+### triggerDownloadSpreadsheet
 
 This method triggers the Spreadsheet Download without the need to open the spreadsheet upload dialog.  
-The input parameter for `triggerSpreadsheetDownload` is the same as the configuration for the `spreadsheetExportConfig` in the `pro` section of the component data.  
-You can overwrite the configuration from the component data by passing the configuration to the `triggerSpreadsheetDownload` method.
+The input parameter for `triggerDownloadSpreadsheet` is the same as the configuration for the `deepDownloadConfig`.  
+You can overwrite the configuration from the component data by passing the configuration to the `triggerDownloadSpreadsheet` method.
 
 ```js
 download: async function () {
@@ -119,7 +155,8 @@ download: async function () {
                 }
             }
         });
-    this.spreadsheetUpload.triggerSpreadsheetDownload({
+    this.spreadsheetUpload.triggerDownloadSpreadsheet({
+        deepLevel: 2,
         deepExport: true,
         addKeysToExport: true
     });

--- a/docs/pages/spreadsheetdownload.md
+++ b/docs/pages/spreadsheetdownload.md
@@ -1,9 +1,10 @@
-This feature downloads data from the backend and converts it to a Spreadsheet file.  
-In the future, the feature will allow users to upload data in order to update the data in the backend.  
+# Spreadsheet Deep Download
+
+This feature downloads data from the backend and converts it to a Spreadsheet file. In the future, the feature will allow users to upload data in order to update the data in the backend.
+
 The main difference between this feature and the integrated Spreadsheet Download is that it can download data from multiple entities at once.
 
-For example, if you have Orders and OrderItems, you can download both entities at once and the data will be structured in the Spreadsheet file in a way that allows for easy data updates and re-uploading.  
-It is also possible to recursively download data from multiple entities indefinitely.
+For example, if you have Orders and OrderItems, you can download both entities at once and the data will be structured in the Spreadsheet file in a way that allows for easy data updates and re-uploading. It is also possible to recursively download data from multiple entities indefinitely.
 
 - Orders
     - OrderItems
@@ -12,20 +13,38 @@ It is also possible to recursively download data from multiple entities indefini
 
 This means that you can download all Orders, including the OrderItems, ShippingInfos, and the Info of the OrderItems.
 
+## Technical Details
+
+The download process involves several key components:
+
+1. **Data Fetching**: The system fetches data recursively based on the configured deep level with expands, handling batch processing for large datasets.
+
+2. **Data Assignment**: The DataAssigner handles:
+   - Root entity data assignment
+   - Column assignments
+   - Recursive data assignment for nested entities
+   - Handling of fetchable entities
+
+3. **Spreadsheet Generation**: The SpreadsheetGenerator creates:
+   - Multiple sheets for different entities
+   - Proper column formatting based on data types
+   - Sheet naming with collision handling
+   - Column width optimization
+
 ## Configuration
 
-| Option | Description | Details |
-| ------ | --- | --- |
-| `addKeysToExport` | Adds hidden keys to the export | object |
-| `filename` | Defines the filename for the export XLSX file | object |
-| `deepExport` | Also exports sibling entities | object |
-| `deepLevel` | Defines the level of sibling entities to export | object |
-| `showOptions` | Shows options dialog for users to change configurations | object |
-| `columns` | Defines the columns to export | object |
+| Option | Description | Default | Type |
+| ------ | ----------- | ------- | ---- |
+| `addKeysToExport` | Adds hidden keys to the export | `false` | boolean |
+| `filename` | Defines the filename for the export XLSX file | Entity Name | string |
+| `deepExport` | Also exports sibling entities | `false` | boolean |
+| `deepLevel` | Defines the level of sibling entities to export | `1` | number |
+| `showOptions` | Shows options dialog for users | `true` | boolean |
+| `columns` | Defines the columns to export | `{}` | object |
 
 ### Sample Usage
 
-The configuration is done in the `pro` section of the component data.
+The configuration is done in the `pro` section of the component data:
 
 ```json
 componentData: {

--- a/examples/package.json
+++ b/examples/package.json
@@ -18,6 +18,7 @@
     "start:uiv2fenondraft": "pnpm --filter ordersv2fenondraft start",
     "start:uiv2fe": "pnpm --filter ordersv2fe start",
     "start:uiv2freestyle": "pnpm --filter ordersv2freestyle start",
+    "start:uiv24reestyle": "pnpm --filter ordersv4freestyle start",
     "start:uiv4fpm": "pnpm --filter ordersv4fpm start",
     "watch:server": "pnpm --filter @capire/orders watch",
     "test": "wdio run ./test/wdio-base.conf.js",
@@ -36,6 +37,7 @@
     "wdio-chromedriver-service": "8.1.1",
     "wdio-ui5-service": "3.0.0-rc.0",
     "webdriverio": "^9.2.8",
-    "wdio-timeline-reporter": "5.1.4"
+    "wdio-timeline-reporter": "5.1.4",
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
   }
 }

--- a/examples/packages/ordersv2freestylenondraft/webapp/view/List.view.xml
+++ b/examples/packages/ordersv2freestylenondraft/webapp/view/List.view.xml
@@ -14,8 +14,29 @@
           usage="spreadsheetImporter"
           propagateModel="true"
           async="true"
-          settings="{tableId:'container-todo---list--list',componentContainerData:{uploadButtonPress:'uploadButtonPress',buttonText:'Excel Upload'}}"
+          settings="{tableId:'container-todo---list--list',
+          componentContainerData:{uploadButtonPress:'uploadButtonPress',buttonText:'Excel Download',downloadButton:true},
+          deepDownloadConfig:{deepLevel: 2,
+            deepExport: true,
+            addKeysToExport: true,
+            showOptions: true,
+            filename: 'Orders12',
+            columns : {
+              'OrderNo':{
+                  'order': 1
+              }
+            }
+          }
+        }"
         />
+        <core:ComponentContainer
+        id="123"
+        width="100%"
+        usage="spreadsheetImporter"
+        propagateModel="true"
+        async="true"
+        settings="{tableId:'container-todo---list--list',componentContainerData:{uploadButtonPress:'uploadButtonPress',buttonText:'Upload Download',downloadButton:false}}"
+      />
         <List
           id="list"
           width="auto"

--- a/examples/packages/ordersv2freestylenondraft/webapp/view/List.view.xml
+++ b/examples/packages/ordersv2freestylenondraft/webapp/view/List.view.xml
@@ -9,27 +9,6 @@
     <semantic:content>
       <VBox>
         <core:ComponentContainer
-          id="test"
-          width="100%"
-          usage="spreadsheetImporter"
-          propagateModel="true"
-          async="true"
-          settings="{tableId:'container-todo---list--list',
-          componentContainerData:{uploadButtonPress:'uploadButtonPress',buttonText:'Excel Download',downloadButton:true},
-          deepDownloadConfig:{deepLevel: 2,
-            deepExport: true,
-            addKeysToExport: true,
-            showOptions: true,
-            filename: 'Orders12',
-            columns : {
-              'OrderNo':{
-                  'order': 1
-              }
-            }
-          }
-        }"
-        />
-        <core:ComponentContainer
         id="123"
         width="100%"
         usage="spreadsheetImporter"

--- a/examples/packages/ordersv2freestylenondraft2/webapp/manifest.json
+++ b/examples/packages/ordersv2freestylenondraft2/webapp/manifest.json
@@ -54,7 +54,7 @@
         "sap.ui.table": {}
       },
       "components": {
-        "cc.spreadsheetimporter.v0_29_1": {}
+        "cc.spreadsheetimporter.v1_4_3": {}
       }
     },
     "contentDensities": {
@@ -79,14 +79,14 @@
     },
     "componentUsages": {
       "spreadsheetImporter": {
-        "name": "cc.spreadsheetimporter.v0_29_1",
+        "name": "cc.spreadsheetimporter.v1_4_3",
         "settings": {},
         "componentData": {},
         "lazy": false
       }
     },
     "resourceRoots": {
-      "cc.spreadsheetimporter.v0_29_1": "./thirdparty/customcontrol/spreadsheetimporter/v0_29_1"
+      "cc.spreadsheetimporter.v1_4_3": "./thirdparty/customcontrol/spreadsheetimporter/v1_4_3"
     },
     "routing": {
       "config": {

--- a/examples/packages/ordersv4fe/ui5-mock.yaml
+++ b/examples/packages/ordersv4fe/ui5-mock.yaml
@@ -29,7 +29,7 @@ server:
       configuration:
         mountPath: /
         services:
-          - urlPath: /orders
+          - urlPath: /odata/v4/Orders
             metadataPath: ./webapp/localService/metadata.xml
             mockdataPath: ./webapp/localService/data
             generateMockData: true

--- a/examples/packages/ordersv4fe/webapp/ext/ListReportExtController.js
+++ b/examples/packages/ordersv4fe/webapp/ext/ListReportExtController.js
@@ -20,11 +20,14 @@ sap.ui.define(["sap/m/MessageToast"], function (MessageToast) {
 							context: this,
 							createActiveEntity: true,
 							i18nModel: this.getModel("i18n"),
+							debug: true,
+							showDownloadButton: true,
 							deepDownloadConfig: {
 								deepLevel: 1,
-								deepExport: true,
-								addKeysToExport: false,
-								showOptions: false,
+								deepExport: false,
+								addKeysToExport: true,
+								showOptions: true,
+								filename: "Orders123",
 								columns : {
 									"OrderNo":{
 										"order": 1
@@ -115,6 +118,31 @@ sap.ui.define(["sap/m/MessageToast"], function (MessageToast) {
 			}, this);
 
 			this.spreadsheetUpload.openSpreadsheetUploadDialog();
+			// this.spreadsheetUpload.triggerDownloadSpreadsheet({
+			// 	deepLevel: 1,
+			// 	deepExport: true,
+			// 	addKeysToExport: true,
+			// 	showOptions: true,
+			// 	filename: "Orders12",
+			// 	columns : {
+			// 		"OrderNo":{
+			// 			"order": 1
+			// 		},
+			// 		"buyer": {
+			// 			"order": 3
+			// 		},
+			// 		"Items": {
+			// 			"quantity" : {
+			// 				"order": 2
+			// 			}
+			// 		},
+			// 		"Shipping": {
+			// 			"address" : {
+			// 				"order": 5
+			// 			},
+			// 		}
+			// 	}
+			// });
 			this.editFlow.getView().setBusy(false);
 		},
 

--- a/examples/packages/ordersv4fe/webapp/ext/ListReportExtController.js
+++ b/examples/packages/ordersv4fe/webapp/ext/ListReportExtController.js
@@ -21,10 +21,10 @@ sap.ui.define(["sap/m/MessageToast"], function (MessageToast) {
 							createActiveEntity: true,
 							i18nModel: this.getModel("i18n"),
 							deepDownloadConfig: {
-								deepLevel: 2,
+								deepLevel: 1,
 								deepExport: true,
-								addKeysToExport: true,
-								showOptions: true,
+								addKeysToExport: false,
+								showOptions: false,
 								columns : {
 									"OrderNo":{
 										"order": 1

--- a/examples/packages/ordersv4fe/webapp/ext/ListReportExtController.js
+++ b/examples/packages/ordersv4fe/webapp/ext/ListReportExtController.js
@@ -19,7 +19,34 @@ sap.ui.define(["sap/m/MessageToast"], function (MessageToast) {
 						componentData: {
 							context: this,
 							createActiveEntity: true,
-							i18nModel: this.getModel("i18n")
+							i18nModel: this.getModel("i18n"),
+							deepDownloadConfig: {
+								deepLevel: 2,
+								deepExport: true,
+								addKeysToExport: true,
+								showOptions: true,
+								columns : {
+									"OrderNo":{
+										"order": 1
+									},
+									"buyer": {
+										"order": 3
+									},
+									"Items": {
+										"quantity" : {
+											"order": 2
+										},
+										"title": {
+											"order": 4
+										}
+									},
+									"Shipping": {
+										"address" : {
+											"order": 5
+										},
+									}
+								}
+							}
 						}
 					});
 			

--- a/examples/packages/ordersv4freestyle/.gitignore
+++ b/examples/packages/ordersv4freestyle/.gitignore
@@ -1,0 +1,10 @@
+node_modules/
+dist/
+.scp/
+.env
+Makefile*.mta
+mta_archives
+mta-*
+resources
+archive.zip
+.*_mta_build_tmp

--- a/examples/packages/ordersv4freestyle/README.md
+++ b/examples/packages/ordersv4freestyle/README.md
@@ -1,0 +1,42 @@
+## Application Details
+|               |
+| ------------- |
+|**Generation Date and Time**<br>Fri Dec 06 2024 08:29:47 GMT+0100 (Mitteleuropäische Normalzeit)|
+|**App Generator**<br>@sap/generator-fiori-freestyle|
+|**App Generator Version**<br>1.12.4|
+|**Generation Platform**<br>Visual Studio Code|
+|**Template Used**<br>simple|
+|**Service Type**<br>OData Url|
+|**Service URL**<br>http://localhost:4004/odata/v4/Orders/
+|**Module Name**<br>ordersv4freestyle|
+|**Application Title**<br>OrdersV4 Freestyle 120|
+|**Namespace**<br>|
+|**UI5 Theme**<br>sap_horizon|
+|**UI5 Version**<br>1.120.24|
+|**Enable Code Assist Libraries**<br>False|
+|**Enable TypeScript**<br>False|
+|**Add Eslint configuration**<br>False|
+
+## ordersv4freestyle
+
+An SAP Fiori application.
+
+### Starting the generated app
+
+-   This app has been generated using the SAP Fiori tools - App Generator, as part of the SAP Fiori tools suite.  In order to launch the generated app, simply run the following from the generated app root folder:
+
+```
+    npm start
+```
+
+- It is also possible to run the application using mock data that reflects the OData Service URL supplied during application generation.  In order to run the application with Mock Data, run the following from the generated app root folder:
+
+```
+    npm run start-mock
+```
+
+#### Pre-requisites:
+
+1. Active NodeJS LTS (Long Term Support) version and associated supported NPM version.  (See https://nodejs.org)
+
+

--- a/examples/packages/ordersv4freestyle/package.json
+++ b/examples/packages/ordersv4freestyle/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "ordersv4freestyle",
+  "version": "0.0.1",
+  "private": true,
+  "description": "An SAP Fiori application.",
+  "keywords": [
+    "ui5",
+    "openui5",
+    "sapui5"
+  ],
+  "main": "webapp/index.html",
+  "dependencies": {},
+  "devDependencies": {
+    "@ui5/cli": "^3.0.0",
+    "@sap/ux-ui5-tooling": "1",
+    "@sap-ux/ui5-middleware-fe-mockserver": "2"
+  },
+  "scripts": {
+    "start": "fiori run --open \"test/flpSandbox.html?sap-ui-xx-viewCache=false#ordersv4freestyle-display\"",
+    "start-local": "fiori run --config ./ui5-local.yaml --open \"test/flpSandbox.html?sap-ui-xx-viewCache=false#ordersv4freestyle-display\"",
+    "build": "ui5 build --config=ui5.yaml --clean-dest --dest dist",
+    "deploy": "fiori verify",
+    "deploy-config": "fiori add deploy-config",
+    "start-noflp": "fiori run --open \"index.html?sap-ui-xx-viewCache=false\"",
+    "start-mock": "fiori run --config ./ui5-mock.yaml --open \"test/flpSandbox.html?sap-ui-xx-viewCache=false#ordersv4freestyle-display\"",
+    "start-variants-management": "fiori run --open \"preview.html?sap-ui-xx-viewCache=false&fiori-tools-rta-mode=true&sap-ui-rta-skip-flex-validation=true#preview-app\"",
+    "unit-tests": "fiori run --config ./ui5-mock.yaml --open 'test/unit/unitTests.qunit.html'",
+    "int-tests": "fiori run --config ./ui5-mock.yaml --open 'test/integration/opaTests.qunit.html'"
+  },
+  "sapuxLayer": "CUSTOMER_BASE"
+}

--- a/examples/packages/ordersv4freestyle/package.json
+++ b/examples/packages/ordersv4freestyle/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ordersv4freestyle",
+  "name": "ordersv4freestyle120",
   "version": "0.0.1",
   "private": true,
   "description": "An SAP Fiori application.",

--- a/examples/packages/ordersv4freestyle/package.json
+++ b/examples/packages/ordersv4freestyle/package.json
@@ -9,14 +9,19 @@
     "sapui5"
   ],
   "main": "webapp/index.html",
-  "dependencies": {},
+  "dependencies": {
+    "ui5-cc-spreadsheetimporter": "link:../../../packages/ui5-cc-spreadsheetimporter"
+  },
   "devDependencies": {
     "@ui5/cli": "^3.0.0",
     "@sap/ux-ui5-tooling": "1",
-    "@sap-ux/ui5-middleware-fe-mockserver": "2"
+    "@sap-ux/ui5-middleware-fe-mockserver": "2",
+    "ui5-middleware-ui5": "3.2.1",
+    "ui5-tooling-modules": "3.18.0"
   },
   "scripts": {
-    "start": "fiori run --open \"test/flpSandbox.html?sap-ui-xx-viewCache=false#ordersv4freestyle-display\"",
+    "start": "fiori run -p 8190 --open \"index.html?sap-ui-xx-viewCache=false\"",
+    "start:silent": "fiori run -p 8190",
     "start-local": "fiori run --config ./ui5-local.yaml --open \"test/flpSandbox.html?sap-ui-xx-viewCache=false#ordersv4freestyle-display\"",
     "build": "ui5 build --config=ui5.yaml --clean-dest --dest dist",
     "deploy": "fiori verify",

--- a/examples/packages/ordersv4freestyle/ui5-local.yaml
+++ b/examples/packages/ordersv4freestyle/ui5-local.yaml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=https://sap.github.io/ui5-tooling/schema/ui5.yaml.json
+
+specVersion: "3.1"
+metadata:
+  name: ordersv4freestyle
+type: application
+framework:
+  name: SAPUI5
+  version: 1.120.24
+  libraries:
+    - name: sap.m
+    - name: sap.ui.core
+    - name: sap.f
+    - name: sap.suite.ui.generic.template
+    - name: sap.ui.comp
+    - name: sap.ui.generic.app
+    - name: sap.ui.table
+    - name: sap.ushell
+    - name: themelib_sap_horizon
+server:
+  customMiddleware:
+    - name: fiori-tools-appreload
+      afterMiddleware: compression
+      configuration:
+        port: 35729
+        path: webapp
+        delay: 300
+    - name: fiori-tools-proxy
+      afterMiddleware: compression
+      configuration:
+        ignoreCertError: false # If set to true, certificate errors will be ignored. E.g. self-signed certificates will be accepted
+        backend:
+          - path: /odata
+            url: http://localhost:4004
+    - name: sap-fe-mockserver
+      beforeMiddleware: csp
+      configuration:
+        mountPath: /
+        services:
+          - urlPath: /odata/v4/Orders
+            metadataPath: ./webapp/localService/metadata.xml
+            mockdataPath: ./webapp/localService/data
+            generateMockData: true
+        annotations: []
+    - name: fiori-tools-preview
+      afterMiddleware: fiori-tools-appreload
+      configuration:
+        component: ordersv4freestyle
+        ui5Theme: sap_horizon

--- a/examples/packages/ordersv4freestyle/ui5-mock.yaml
+++ b/examples/packages/ordersv4freestyle/ui5-mock.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://sap.github.io/ui5-tooling/schema/ui5.yaml.json
+
+specVersion: "3.1"
+metadata:
+  name: ordersv4freestyle
+type: application
+server:
+  customMiddleware:
+    - name: fiori-tools-proxy
+      afterMiddleware: compression
+      configuration:
+        ignoreCertError: false # If set to true, certificate errors will be ignored. E.g. self-signed certificates will be accepted
+        ui5:
+          path:
+            - /resources
+            - /test-resources
+          url: https://ui5.sap.com
+        backend:
+          - path: /odata
+            url: http://localhost:4004
+    - name: fiori-tools-appreload
+      afterMiddleware: compression
+      configuration:
+        port: 35729
+        path: webapp
+        delay: 300
+    - name: sap-fe-mockserver
+      beforeMiddleware: csp
+      configuration:
+        mountPath: /
+        services:
+          - urlPath: /odata/v4/Orders
+            metadataPath: ./webapp/localService/metadata.xml
+            mockdataPath: ./webapp/localService/data
+            generateMockData: true
+        annotations: []

--- a/examples/packages/ordersv4freestyle/ui5-test.yaml
+++ b/examples/packages/ordersv4freestyle/ui5-test.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://sap.github.io/ui5-tooling/schema/ui5.yaml.json
+
+specVersion: "3.1"
+metadata:
+  name: ordersv4freestyle
+type: application
+server:
+  customMiddleware:
+    - name: fiori-tools-proxy
+      afterMiddleware: compression
+      configuration:
+        ignoreCertError: false # If set to true, certificate errors will be ignored. E.g. self-signed certificates will be accepted
+        ui5:
+          path:
+            - /resources
+            - /test-resources
+          url: https://ui5.sap.com
+        backend:
+          - path: /odata
+            url: http://localhost:4004

--- a/examples/packages/ordersv4freestyle/ui5.yaml
+++ b/examples/packages/ordersv4freestyle/ui5.yaml
@@ -18,6 +18,18 @@ server:
         backend:
           - path: /odata
             url: http://localhost:4004
+    - name: ui5-middleware-ui5
+      afterMiddleware: compression
+      configuration:
+        modules:
+          ui5-cc-spreadsheetimporter:
+            configFile: "ui5-serve.yaml"
+    - name: ui5-tooling-modules-middleware
+      afterMiddleware: compression
+      configuration:
+        debug: "verbose"
+        addToNamespace: true
+        prependPathMappings: true
     - name: fiori-tools-appreload
       afterMiddleware: compression
       configuration:

--- a/examples/packages/ordersv4freestyle/ui5.yaml
+++ b/examples/packages/ordersv4freestyle/ui5.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://sap.github.io/ui5-tooling/schema/ui5.yaml.json
+
+specVersion: "3.1"
+metadata:
+  name: ordersv4freestyle
+type: application
+server:
+  customMiddleware:
+    - name: fiori-tools-proxy
+      afterMiddleware: compression
+      configuration:
+        ignoreCertError: false # If set to true, certificate errors will be ignored. E.g. self-signed certificates will be accepted
+        ui5:
+          path:
+            - /resources
+            - /test-resources
+          url: https://ui5.sap.com
+        backend:
+          - path: /odata
+            url: http://localhost:4004
+    - name: fiori-tools-appreload
+      afterMiddleware: compression
+      configuration:
+        port: 35729
+        path: webapp
+        delay: 300
+    - name: fiori-tools-preview
+      afterMiddleware: fiori-tools-appreload
+      configuration:
+        component: ordersv4freestyle
+        ui5Theme: sap_horizon

--- a/examples/packages/ordersv4freestyle/webapp/Component.js
+++ b/examples/packages/ordersv4freestyle/webapp/Component.js
@@ -1,0 +1,35 @@
+/**
+ * eslint-disable @sap/ui5-jsdocs/no-jsdoc
+ */
+
+sap.ui.define([
+        "sap/ui/core/UIComponent",
+        "sap/ui/Device",
+        "ordersv4freestyle/model/models"
+    ],
+    function (UIComponent, Device, models) {
+        "use strict";
+
+        return UIComponent.extend("ordersv4freestyle.Component", {
+            metadata: {
+                manifest: "json"
+            },
+
+            /**
+             * The component is initialized by UI5 automatically during the startup of the app and calls the init method once.
+             * @public
+             * @override
+             */
+            init: function () {
+                // call the base component's init function
+                UIComponent.prototype.init.apply(this, arguments);
+
+                // enable routing
+                this.getRouter().initialize();
+
+                // set the device model
+                this.setModel(models.createDeviceModel(), "device");
+            }
+        });
+    }
+);

--- a/examples/packages/ordersv4freestyle/webapp/controller/App.controller.js
+++ b/examples/packages/ordersv4freestyle/webapp/controller/App.controller.js
@@ -1,0 +1,14 @@
+sap.ui.define(
+    [
+        "sap/ui/core/mvc/Controller"
+    ],
+    function(BaseController) {
+      "use strict";
+  
+      return BaseController.extend("ordersv4freestyle.controller.App", {
+        onInit: function() {
+        }
+      });
+    }
+  );
+  

--- a/examples/packages/ordersv4freestyle/webapp/controller/MainView.controller.js
+++ b/examples/packages/ordersv4freestyle/webapp/controller/MainView.controller.js
@@ -10,6 +10,49 @@ sap.ui.define([
         return Controller.extend("ordersv4freestyle.controller.MainView", {
             onInit: function () {
 
+            },
+
+            onDownload: async function () {
+                this.spreadsheetUpload = await this.getView().getController().getOwnerComponent()
+                .createComponent({
+                    usage: "spreadsheetImporter",
+                    async: true,
+                    componentData: {
+                        context: this,
+                        createActiveEntity: true,
+                        debug: true,
+                        deepDownloadConfig: {
+                            deepLevel: 2,
+                            deepExport: true,
+                            addKeysToExport: true,
+                            showOptions: false,
+                            filename: "Orders123",
+                            columns : {
+                                "OrderNo":{
+                                    "order": 1
+                                },
+                                "buyer": {
+                                    "order": 3
+                                },
+                                "Items": {
+                                    "quantity" : {
+                                        "order": 2
+                                    },
+                                    "title": {
+                                        "order": 4
+                                    }
+                                },
+                                "Shipping": {
+                                    "address" : {
+                                        "order": 5
+                                    },
+                                }
+                            }
+                        }
+                    }
+                });
+
+                this.spreadsheetUpload.triggerDownloadSpreadsheet();
             }
         });
     });

--- a/examples/packages/ordersv4freestyle/webapp/controller/MainView.controller.js
+++ b/examples/packages/ordersv4freestyle/webapp/controller/MainView.controller.js
@@ -20,7 +20,7 @@ sap.ui.define([
                     componentData: {
                         context: this,
                         createActiveEntity: true,
-                        debug: true,
+                        debug: false,
                         deepDownloadConfig: {
                             deepLevel: 2,
                             deepExport: true,
@@ -52,7 +52,18 @@ sap.ui.define([
                     }
                 });
 
+                // this.spreadsheetUpload.attachBeforeDownloadFileProcessing(this.onBeforeDownloadFileProcessing, this);
+                // this.spreadsheetUpload.attachBeforeDownloadFileExport(this.onBeforeDownloadFileExport, this);
+
                 this.spreadsheetUpload.triggerDownloadSpreadsheet();
-            }
+            },
+
+            // onBeforeDownloadFileProcessing: function (event) {
+            //     event.getParameters().data.$XYZData[0].buyer = "Customer 123";
+            // },
+
+            // onBeforeDownloadFileExport: function (event) {
+            //     event.getParameters().filename = "Orders123_modified";
+            // }
         });
     });

--- a/examples/packages/ordersv4freestyle/webapp/controller/MainView.controller.js
+++ b/examples/packages/ordersv4freestyle/webapp/controller/MainView.controller.js
@@ -1,0 +1,15 @@
+sap.ui.define([
+    "sap/ui/core/mvc/Controller"
+],
+    /**
+     * @param {typeof sap.ui.core.mvc.Controller} Controller
+     */
+    function (Controller) {
+        "use strict";
+
+        return Controller.extend("ordersv4freestyle.controller.MainView", {
+            onInit: function () {
+
+            }
+        });
+    });

--- a/examples/packages/ordersv4freestyle/webapp/css/style.css
+++ b/examples/packages/ordersv4freestyle/webapp/css/style.css
@@ -1,0 +1,1 @@
+/* Enter your custom styles here */

--- a/examples/packages/ordersv4freestyle/webapp/i18n/i18n.properties
+++ b/examples/packages/ordersv4freestyle/webapp/i18n/i18n.properties
@@ -1,0 +1,11 @@
+# This is the resource bundle for ordersv4freestyle
+
+#Texts for manifest.json
+
+#XTIT: Application name
+appTitle=OrdersV4 Freestyle 120
+
+#YDES: Application description
+appDescription=An SAP Fiori application.
+#XTIT: Main view title
+title=OrdersV4 Freestyle 120

--- a/examples/packages/ordersv4freestyle/webapp/i18n/i18n.properties
+++ b/examples/packages/ordersv4freestyle/webapp/i18n/i18n.properties
@@ -3,7 +3,7 @@
 #Texts for manifest.json
 
 #XTIT: Application name
-appTitle=OrdersV4 Freestyle 120
+appTitle=Orders V4 FS 120
 
 #YDES: Application description
 appDescription=An SAP Fiori application.

--- a/examples/packages/ordersv4freestyle/webapp/index.html
+++ b/examples/packages/ordersv4freestyle/webapp/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>OrdersV4 Freestyle 120</title>
+    <style>
+        html, body, body > div, #container, #container-uiarea {
+            height: 100%;
+        }
+    </style>
+    <script
+        id="sap-ui-bootstrap"
+        src="resources/sap-ui-core.js"
+        data-sap-ui-theme="sap_horizon"
+        data-sap-ui-resourceroots='{
+            "ordersv4freestyle": "./"
+        }'
+        data-sap-ui-oninit="module:sap/ui/core/ComponentSupport"
+        data-sap-ui-compatVersion="edge"
+        data-sap-ui-async="true"
+        data-sap-ui-frameOptions="trusted"
+    ></script>
+</head>
+<body class="sapUiBody sapUiSizeCompact" id="content">
+    <div
+        data-sap-ui-component
+        data-name="ordersv4freestyle"
+        data-id="container"
+        data-settings='{"id" : "ordersv4freestyle"}'
+        data-handle-validation="true"
+    ></div>
+</body>
+</html>

--- a/examples/packages/ordersv4freestyle/webapp/localService/metadata.xml
+++ b/examples/packages/ordersv4freestyle/webapp/localService/metadata.xml
@@ -1,0 +1,1142 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+    <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/Common.xml">
+        <edmx:Include Alias="Common" Namespace="com.sap.vocabularies.Common.v1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml">
+        <edmx:Include Alias="Core" Namespace="Org.OData.Core.V1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/UI.xml">
+        <edmx:Include Alias="UI" Namespace="com.sap.vocabularies.UI.v1"/>
+    </edmx:Reference>
+    <edmx:DataServices>
+        <Schema Namespace="OrdersService" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+            <Annotation Term="Core.Links">
+                <Collection>
+                    <Record>
+                        <PropertyValue Property="rel" String="author"/>
+                        <PropertyValue Property="href" String="https://cap.cloud.sap"/>
+                    </Record>
+                </Collection>
+            </Annotation>
+            <EntityContainer Name="EntityContainer">
+                <EntitySet Name="Orders" EntityType="OrdersService.Orders">
+                    <NavigationPropertyBinding Path="Items" Target="OrderItems"/>
+                    <NavigationPropertyBinding Path="Shipping" Target="ShippingDetails"/>
+                    <NavigationPropertyBinding Path="currency" Target="Currencies"/>
+                    <NavigationPropertyBinding Path="SiblingEntity" Target="Orders"/>
+                </EntitySet>
+                <EntitySet Name="OrderItems" EntityType="OrdersService.OrderItems">
+                    <NavigationPropertyBinding Path="order" Target="Orders"/>
+                    <NavigationPropertyBinding Path="Infos" Target="OrderItemsInfo"/>
+                    <NavigationPropertyBinding Path="SiblingEntity" Target="OrderItems"/>
+                </EntitySet>
+                <EntitySet Name="OrderItemsInfo" EntityType="OrdersService.OrderItemsInfo">
+                    <NavigationPropertyBinding Path="orderItem" Target="OrderItems"/>
+                    <NavigationPropertyBinding Path="SiblingEntity" Target="OrderItemsInfo"/>
+                </EntitySet>
+                <EntitySet Name="OrdersND" EntityType="OrdersService.OrdersND">
+                    <NavigationPropertyBinding Path="Items" Target="OrderItemsND"/>
+                    <NavigationPropertyBinding Path="currency" Target="Currencies"/>
+                </EntitySet>
+                <EntitySet Name="OrderItemsND" EntityType="OrdersService.OrderItemsND">
+                    <NavigationPropertyBinding Path="order" Target="OrdersND"/>
+                    <NavigationPropertyBinding Path="Infos" Target="OrderItemsInfoND"/>
+                </EntitySet>
+                <EntitySet Name="OrderItemsInfoND" EntityType="OrdersService.OrderItemsInfoND">
+                    <NavigationPropertyBinding Path="orderItem" Target="OrderItemsND"/>
+                </EntitySet>
+                <EntitySet Name="ShippingDetails" EntityType="OrdersService.ShippingDetails">
+                    <NavigationPropertyBinding Path="order" Target="Orders"/>
+                    <NavigationPropertyBinding Path="SiblingEntity" Target="ShippingDetails"/>
+                </EntitySet>
+                <EntitySet Name="Currencies" EntityType="OrdersService.Currencies">
+                    <NavigationPropertyBinding Path="texts" Target="Currencies_texts"/>
+                    <NavigationPropertyBinding Path="localized" Target="Currencies_texts"/>
+                </EntitySet>
+                <EntitySet Name="Currencies_texts" EntityType="OrdersService.Currencies_texts"/>
+            </EntityContainer>
+            <EntityType Name="Orders">
+                <Key>
+                    <PropertyRef Name="ID"/>
+                    <PropertyRef Name="IsActiveEntity"/>
+                </Key>
+                <Property Name="ID" Type="Edm.Guid" Nullable="false"/>
+                <Property Name="createdAt" Type="Edm.DateTimeOffset" Precision="7"/>
+                <Property Name="createdBy" Type="Edm.String" MaxLength="255"/>
+                <Property Name="modifiedAt" Type="Edm.DateTimeOffset" Precision="7"/>
+                <Property Name="modifiedBy" Type="Edm.String" MaxLength="255"/>
+                <Property Name="OrderNo" Type="Edm.String" MaxLength="22"/>
+                <NavigationProperty Name="Items" Type="Collection(OrdersService.OrderItems)" Partner="order">
+                    <OnDelete Action="Cascade"/>
+                </NavigationProperty>
+                <NavigationProperty Name="Shipping" Type="Collection(OrdersService.ShippingDetails)" Partner="order">
+                    <OnDelete Action="Cascade"/>
+                </NavigationProperty>
+                <Property Name="buyer" Type="Edm.String" MaxLength="255"/>
+                <NavigationProperty Name="currency" Type="OrdersService.Currencies">
+                    <ReferentialConstraint Property="currency_code" ReferencedProperty="code"/>
+                </NavigationProperty>
+                <Property Name="currency_code" Type="Edm.String" MaxLength="3"/>
+                <Property Name="spreadsheetRow" Type="Edm.Int32"/>
+                <Property Name="IsActiveEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="true"/>
+                <Property Name="HasActiveEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="false"/>
+                <Property Name="HasDraftEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="false"/>
+                <NavigationProperty Name="DraftAdministrativeData" Type="OrdersService.DraftAdministrativeData" ContainsTarget="true"/>
+                <NavigationProperty Name="SiblingEntity" Type="OrdersService.Orders"/>
+            </EntityType>
+            <EntityType Name="OrderItems">
+                <Key>
+                    <PropertyRef Name="ID"/>
+                    <PropertyRef Name="IsActiveEntity"/>
+                </Key>
+                <Property Name="ID" Type="Edm.Guid" Nullable="false"/>
+                <NavigationProperty Name="order" Type="OrdersService.Orders" Partner="Items">
+                    <ReferentialConstraint Property="order_ID" ReferencedProperty="ID"/>
+                </NavigationProperty>
+                <Property Name="order_ID" Type="Edm.Guid"/>
+                <Property Name="product_ID" Type="Edm.String"/>
+                <NavigationProperty Name="Infos" Type="Collection(OrdersService.OrderItemsInfo)" Partner="orderItem">
+                    <OnDelete Action="Cascade"/>
+                </NavigationProperty>
+                <Property Name="quantity" Type="Edm.Int32"/>
+                <Property Name="title" Type="Edm.String"/>
+                <Property Name="price" Type="Edm.Double"/>
+                <Property Name="validFrom" Type="Edm.DateTimeOffset"/>
+                <Property Name="timestamp" Type="Edm.DateTimeOffset" Precision="7"/>
+                <Property Name="date" Type="Edm.Date"/>
+                <Property Name="time" Type="Edm.TimeOfDay"/>
+                <Property Name="boolean" Type="Edm.Boolean"/>
+                <Property Name="decimal" Type="Edm.Decimal" Precision="15" Scale="3"/>
+                <Property Name="byte" Type="Edm.Byte"/>
+                <Property Name="binary" Type="Edm.Binary"/>
+                <Property Name="IsActiveEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="true"/>
+                <Property Name="HasActiveEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="false"/>
+                <Property Name="HasDraftEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="false"/>
+                <NavigationProperty Name="DraftAdministrativeData" Type="OrdersService.DraftAdministrativeData" ContainsTarget="true"/>
+                <NavigationProperty Name="SiblingEntity" Type="OrdersService.OrderItems"/>
+            </EntityType>
+            <EntityType Name="OrderItemsInfo">
+                <Key>
+                    <PropertyRef Name="ID"/>
+                    <PropertyRef Name="IsActiveEntity"/>
+                </Key>
+                <Property Name="ID" Type="Edm.Guid" Nullable="false"/>
+                <NavigationProperty Name="orderItem" Type="OrdersService.OrderItems" Partner="Infos">
+                    <ReferentialConstraint Property="orderItem_ID" ReferencedProperty="ID"/>
+                </NavigationProperty>
+                <Property Name="orderItem_ID" Type="Edm.Guid"/>
+                <Property Name="comment" Type="Edm.String"/>
+                <Property Name="IsActiveEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="true"/>
+                <Property Name="HasActiveEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="false"/>
+                <Property Name="HasDraftEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="false"/>
+                <NavigationProperty Name="DraftAdministrativeData" Type="OrdersService.DraftAdministrativeData" ContainsTarget="true"/>
+                <NavigationProperty Name="SiblingEntity" Type="OrdersService.OrderItemsInfo"/>
+            </EntityType>
+            <EntityType Name="OrdersND">
+                <Key>
+                    <PropertyRef Name="ID"/>
+                </Key>
+                <Property Name="ID" Type="Edm.Guid" Nullable="false"/>
+                <Property Name="createdAt" Type="Edm.DateTimeOffset" Precision="7"/>
+                <Property Name="createdBy" Type="Edm.String" MaxLength="255"/>
+                <Property Name="modifiedAt" Type="Edm.DateTimeOffset" Precision="7"/>
+                <Property Name="modifiedBy" Type="Edm.String" MaxLength="255"/>
+                <Property Name="OrderNo" Type="Edm.String" MaxLength="22"/>
+                <NavigationProperty Name="Items" Type="Collection(OrdersService.OrderItemsND)" Partner="order">
+                    <OnDelete Action="Cascade"/>
+                </NavigationProperty>
+                <Property Name="buyer" Type="Edm.String" MaxLength="255"/>
+                <NavigationProperty Name="currency" Type="OrdersService.Currencies">
+                    <ReferentialConstraint Property="currency_code" ReferencedProperty="code"/>
+                </NavigationProperty>
+                <Property Name="currency_code" Type="Edm.String" MaxLength="3"/>
+            </EntityType>
+            <EntityType Name="OrderItemsND">
+                <Key>
+                    <PropertyRef Name="ID"/>
+                </Key>
+                <Property Name="ID" Type="Edm.Guid" Nullable="false"/>
+                <NavigationProperty Name="order" Type="OrdersService.OrdersND" Partner="Items">
+                    <ReferentialConstraint Property="order_ID" ReferencedProperty="ID"/>
+                </NavigationProperty>
+                <Property Name="order_ID" Type="Edm.Guid"/>
+                <Property Name="product_ID" Type="Edm.String"/>
+                <NavigationProperty Name="Infos" Type="Collection(OrdersService.OrderItemsInfoND)" Partner="orderItem">
+                    <OnDelete Action="Cascade"/>
+                </NavigationProperty>
+                <Property Name="quantity" Type="Edm.Int32"/>
+                <Property Name="title" Type="Edm.String"/>
+                <Property Name="price" Type="Edm.Double"/>
+                <Property Name="validFrom" Type="Edm.DateTimeOffset"/>
+                <Property Name="timestamp" Type="Edm.DateTimeOffset" Precision="7"/>
+                <Property Name="date" Type="Edm.Date"/>
+                <Property Name="time" Type="Edm.TimeOfDay"/>
+                <Property Name="boolean" Type="Edm.Boolean"/>
+                <Property Name="decimal" Type="Edm.Decimal" Precision="15" Scale="3"/>
+                <Property Name="byte" Type="Edm.Byte"/>
+                <Property Name="binary" Type="Edm.Binary"/>
+            </EntityType>
+            <EntityType Name="OrderItemsInfoND">
+                <Key>
+                    <PropertyRef Name="ID"/>
+                </Key>
+                <Property Name="ID" Type="Edm.Guid" Nullable="false"/>
+                <NavigationProperty Name="orderItem" Type="OrdersService.OrderItemsND" Partner="Infos">
+                    <ReferentialConstraint Property="orderItem_ID" ReferencedProperty="ID"/>
+                </NavigationProperty>
+                <Property Name="orderItem_ID" Type="Edm.Guid"/>
+                <Property Name="comment" Type="Edm.String"/>
+            </EntityType>
+            <EntityType Name="ShippingDetails">
+                <Key>
+                    <PropertyRef Name="ID"/>
+                    <PropertyRef Name="IsActiveEntity"/>
+                </Key>
+                <Property Name="ID" Type="Edm.Guid" Nullable="false"/>
+                <NavigationProperty Name="order" Type="OrdersService.Orders" Partner="Shipping">
+                    <ReferentialConstraint Property="order_ID" ReferencedProperty="ID"/>
+                </NavigationProperty>
+                <Property Name="order_ID" Type="Edm.Guid"/>
+                <Property Name="address" Type="Edm.String"/>
+                <Property Name="city" Type="Edm.String"/>
+                <Property Name="state" Type="Edm.String"/>
+                <Property Name="postalCode" Type="Edm.String"/>
+                <Property Name="country" Type="Edm.String"/>
+                <Property Name="shipmentDate" Type="Edm.DateTimeOffset"/>
+                <Property Name="arrivalDate" Type="Edm.DateTimeOffset"/>
+                <Property Name="shipmentStatus" Type="Edm.String"/>
+                <Property Name="IsActiveEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="true"/>
+                <Property Name="HasActiveEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="false"/>
+                <Property Name="HasDraftEntity" Type="Edm.Boolean" Nullable="false" DefaultValue="false"/>
+                <NavigationProperty Name="DraftAdministrativeData" Type="OrdersService.DraftAdministrativeData" ContainsTarget="true"/>
+                <NavigationProperty Name="SiblingEntity" Type="OrdersService.ShippingDetails"/>
+            </EntityType>
+            <EntityType Name="Currencies">
+                <Key>
+                    <PropertyRef Name="code"/>
+                </Key>
+                <Property Name="name" Type="Edm.String" MaxLength="255"/>
+                <Property Name="descr" Type="Edm.String" MaxLength="1000"/>
+                <Property Name="code" Type="Edm.String" MaxLength="3" Nullable="false"/>
+                <Property Name="symbol" Type="Edm.String" MaxLength="5"/>
+                <Property Name="minorUnit" Type="Edm.Int16"/>
+                <NavigationProperty Name="texts" Type="Collection(OrdersService.Currencies_texts)">
+                    <OnDelete Action="Cascade"/>
+                </NavigationProperty>
+                <NavigationProperty Name="localized" Type="OrdersService.Currencies_texts">
+                    <ReferentialConstraint Property="code" ReferencedProperty="code"/>
+                </NavigationProperty>
+            </EntityType>
+            <EntityType Name="DraftAdministrativeData">
+                <Key>
+                    <PropertyRef Name="DraftUUID"/>
+                </Key>
+                <Property Name="DraftUUID" Type="Edm.Guid" Nullable="false"/>
+                <Property Name="CreationDateTime" Type="Edm.DateTimeOffset" Precision="7"/>
+                <Property Name="CreatedByUser" Type="Edm.String" MaxLength="256"/>
+                <Property Name="DraftIsCreatedByMe" Type="Edm.Boolean"/>
+                <Property Name="LastChangeDateTime" Type="Edm.DateTimeOffset" Precision="7"/>
+                <Property Name="LastChangedByUser" Type="Edm.String" MaxLength="256"/>
+                <Property Name="InProcessByUser" Type="Edm.String" MaxLength="256"/>
+                <Property Name="DraftIsProcessedByMe" Type="Edm.Boolean"/>
+            </EntityType>
+            <EntityType Name="Currencies_texts">
+                <Key>
+                    <PropertyRef Name="locale"/>
+                    <PropertyRef Name="code"/>
+                </Key>
+                <Property Name="locale" Type="Edm.String" MaxLength="14" Nullable="false"/>
+                <Property Name="name" Type="Edm.String" MaxLength="255"/>
+                <Property Name="descr" Type="Edm.String" MaxLength="1000"/>
+                <Property Name="code" Type="Edm.String" MaxLength="3" Nullable="false"/>
+            </EntityType>
+            <Action Name="draftPrepare" IsBound="true" EntitySetPath="in">
+                <Parameter Name="in" Type="OrdersService.Orders"/>
+                <Parameter Name="SideEffectsQualifier" Type="Edm.String"/>
+                <ReturnType Type="OrdersService.Orders"/>
+            </Action>
+            <Action Name="draftPrepare" IsBound="true" EntitySetPath="in">
+                <Parameter Name="in" Type="OrdersService.OrderItems"/>
+                <Parameter Name="SideEffectsQualifier" Type="Edm.String"/>
+                <ReturnType Type="OrdersService.OrderItems"/>
+            </Action>
+            <Action Name="draftPrepare" IsBound="true" EntitySetPath="in">
+                <Parameter Name="in" Type="OrdersService.OrderItemsInfo"/>
+                <Parameter Name="SideEffectsQualifier" Type="Edm.String"/>
+                <ReturnType Type="OrdersService.OrderItemsInfo"/>
+            </Action>
+            <Action Name="draftPrepare" IsBound="true" EntitySetPath="in">
+                <Parameter Name="in" Type="OrdersService.ShippingDetails"/>
+                <Parameter Name="SideEffectsQualifier" Type="Edm.String"/>
+                <ReturnType Type="OrdersService.ShippingDetails"/>
+            </Action>
+            <Action Name="draftActivate" IsBound="true" EntitySetPath="in">
+                <Parameter Name="in" Type="OrdersService.Orders"/>
+                <ReturnType Type="OrdersService.Orders"/>
+            </Action>
+            <Action Name="draftEdit" IsBound="true" EntitySetPath="in">
+                <Parameter Name="in" Type="OrdersService.Orders"/>
+                <Parameter Name="PreserveChanges" Type="Edm.Boolean"/>
+                <ReturnType Type="OrdersService.Orders"/>
+            </Action>
+            <Annotations Target="OrdersService.Orders">
+                <Annotation Term="UI.SelectionFields">
+                    <Collection>
+                        <PropertyPath>createdBy</PropertyPath>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.LineItem">
+                    <Collection>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="OrderNo"/>
+                            <PropertyValue Property="Label" String="OrderNo"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="buyer"/>
+                            <PropertyValue Property="Label" String="Customer"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="currency/symbol"/>
+                            <PropertyValue Property="Label" String="Currency"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="createdAt"/>
+                            <PropertyValue Property="Label" String="Date"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.HeaderInfo">
+                    <Record Type="UI.HeaderInfoType">
+                        <PropertyValue Property="TypeName" String="Order"/>
+                        <PropertyValue Property="TypeNamePlural" String="Orders"/>
+                        <PropertyValue Property="Title">
+                            <Record Type="UI.DataField">
+                                <PropertyValue Property="Label" String="OrderNo"/>
+                                <PropertyValue Property="Value" Path="OrderNo"/>
+                            </Record>
+                        </PropertyValue>
+                        <PropertyValue Property="Description">
+                            <Record Type="UI.DataField">
+                                <PropertyValue Property="Value" Path="createdBy"/>
+                            </Record>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="UI.Identification">
+                    <Collection>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="createdBy"/>
+                            <PropertyValue Property="Label" String="Customer"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="createdAt"/>
+                            <PropertyValue Property="Label" String="Date"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="OrderNo"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.HeaderFacets">
+                    <Collection>
+                        <Record Type="UI.ReferenceFacet">
+                            <PropertyValue Property="Label" String="Created"/>
+                            <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#Created"/>
+                        </Record>
+                        <Record Type="UI.ReferenceFacet">
+                            <PropertyValue Property="Label" String="Modified"/>
+                            <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#Modified"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.Facets">
+                    <Collection>
+                        <Record Type="UI.ReferenceFacet">
+                            <PropertyValue Property="Label" String="Details"/>
+                            <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#Details"/>
+                        </Record>
+                        <Record Type="UI.ReferenceFacet">
+                            <PropertyValue Property="Label" String="OrderItems"/>
+                            <PropertyValue Property="Target" AnnotationPath="Items/@UI.LineItem"/>
+                        </Record>
+                        <Record Type="UI.ReferenceFacet">
+                            <PropertyValue Property="Label" String="Shipping Details"/>
+                            <PropertyValue Property="Target" AnnotationPath="Shipping/@UI.LineItem"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.FieldGroup" Qualifier="Details">
+                    <Record Type="UI.FieldGroupType">
+                        <PropertyValue Property="Data">
+                            <Collection>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="currency/code"/>
+                                    <PropertyValue Property="Label" String="Currency"/>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="UI.FieldGroup" Qualifier="Created">
+                    <Record Type="UI.FieldGroupType">
+                        <PropertyValue Property="Data">
+                            <Collection>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="createdBy"/>
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="createdAt"/>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="UI.FieldGroup" Qualifier="Modified">
+                    <Record Type="UI.FieldGroupType">
+                        <PropertyValue Property="Data">
+                            <Collection>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="modifiedBy"/>
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="modifiedAt"/>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="OrdersService.EntityContainer/Orders">
+                <Annotation Term="Common.DraftRoot">
+                    <Record Type="Common.DraftRootType">
+                        <PropertyValue Property="ActivationAction" String="OrdersService.draftActivate"/>
+                        <PropertyValue Property="EditAction" String="OrdersService.draftEdit"/>
+                        <PropertyValue Property="PreparationAction" String="OrdersService.draftPrepare"/>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="OrdersService.Orders/ID">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+                <Annotation Term="Core.ComputedDefaultValue" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.Orders/createdAt">
+                <Annotation Term="UI.HiddenFilter" Bool="false"/>
+                <Annotation Term="UI.ExcludeFromNavigationContext" Bool="true"/>
+                <Annotation Term="Core.Immutable" Bool="true"/>
+                <Annotation Term="Core.Computed" Bool="true"/>
+                <Annotation Term="Common.Label" String="Created On"/>
+            </Annotations>
+            <Annotations Target="OrdersService.Orders/createdBy">
+                <Annotation Term="UI.HiddenFilter" Bool="false"/>
+                <Annotation Term="UI.ExcludeFromNavigationContext" Bool="true"/>
+                <Annotation Term="Core.Immutable" Bool="true"/>
+                <Annotation Term="Core.Computed" Bool="true"/>
+                <Annotation Term="Core.Description" String="User's unique ID"/>
+                <Annotation Term="Common.Label" String="Created By"/>
+            </Annotations>
+            <Annotations Target="OrdersService.Orders/modifiedAt">
+                <Annotation Term="UI.HiddenFilter" Bool="true"/>
+                <Annotation Term="UI.ExcludeFromNavigationContext" Bool="true"/>
+                <Annotation Term="Core.Computed" Bool="true"/>
+                <Annotation Term="Common.Label" String="Changed On"/>
+            </Annotations>
+            <Annotations Target="OrdersService.Orders/modifiedBy">
+                <Annotation Term="UI.HiddenFilter" Bool="true"/>
+                <Annotation Term="UI.ExcludeFromNavigationContext" Bool="true"/>
+                <Annotation Term="Core.Computed" Bool="true"/>
+                <Annotation Term="Core.Description" String="User's unique ID"/>
+                <Annotation Term="Common.Label" String="Changed By"/>
+            </Annotations>
+            <Annotations Target="OrdersService.Orders/OrderNo">
+                <Annotation Term="Common.Label" String="Order Number"/>
+            </Annotations>
+            <Annotations Target="OrdersService.Orders/buyer">
+                <Annotation Term="Common.Label" String="User ID"/>
+                <Annotation Term="Core.Description" String="User's unique ID"/>
+            </Annotations>
+            <Annotations Target="OrdersService.Orders/currency">
+                <Annotation Term="Common.Label" String="Currency"/>
+                <Annotation Term="Core.Description" String="Currency code as specified by ISO 4217"/>
+            </Annotations>
+            <Annotations Target="OrdersService.Orders/currency_code">
+                <Annotation Term="Common.Label" String="Currency"/>
+                <Annotation Term="Common.ValueList">
+                    <Record Type="Common.ValueListType">
+                        <PropertyValue Property="Label" String="Currency"/>
+                        <PropertyValue Property="CollectionPath" String="Currencies"/>
+                        <PropertyValue Property="Parameters">
+                            <Collection>
+                                <Record Type="Common.ValueListParameterInOut">
+                                    <PropertyValue Property="LocalDataProperty" PropertyPath="currency_code"/>
+                                    <PropertyValue Property="ValueListProperty" String="code"/>
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="name"/>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="Core.Description" String="Currency code as specified by ISO 4217"/>
+            </Annotations>
+            <Annotations Target="OrdersService.Orders/IsActiveEntity">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.Orders/HasActiveEntity">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.Orders/HasDraftEntity">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.Orders/DraftAdministrativeData">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.OrderItems">
+                <Annotation Term="UI.LineItem">
+                    <Collection>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="product_ID"/>
+                            <PropertyValue Property="Label" String="ID"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="title"/>
+                            <PropertyValue Property="Label" String="ProductTitle"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="price"/>
+                            <PropertyValue Property="Label" String="UnitPrice"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="quantity"/>
+                            <PropertyValue Property="Label" String="Quantity"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="validFrom"/>
+                            <PropertyValue Property="Label" String="validFrom"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="timestamp"/>
+                            <PropertyValue Property="Label" String="timestamp"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="date"/>
+                            <PropertyValue Property="Label" String="date"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="time"/>
+                            <PropertyValue Property="Label" String="time"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.Identification">
+                    <Collection>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="quantity"/>
+                            <PropertyValue Property="Label" String="Quantity"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="title"/>
+                            <PropertyValue Property="Label" String="Product"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="price"/>
+                            <PropertyValue Property="Label" String="UnitPrice"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="validFrom"/>
+                            <PropertyValue Property="Label" String="validFrom"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="timestamp"/>
+                            <PropertyValue Property="Label" String="timestamp"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="date"/>
+                            <PropertyValue Property="Label" String="date"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="time"/>
+                            <PropertyValue Property="Label" String="time"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="boolean"/>
+                            <PropertyValue Property="Label" String="time"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.Facets">
+                    <Collection>
+                        <Record Type="UI.ReferenceFacet">
+                            <PropertyValue Property="Label" String="OrderItems"/>
+                            <PropertyValue Property="Target" AnnotationPath="@UI.Identification"/>
+                        </Record>
+                        <Record Type="UI.ReferenceFacet">
+                            <PropertyValue Property="Label" String="Infos"/>
+                            <PropertyValue Property="Target" AnnotationPath="Infos/@UI.LineItem"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="OrdersService.EntityContainer/OrderItems">
+                <Annotation Term="Common.DraftNode">
+                    <Record Type="Common.DraftNodeType">
+                        <PropertyValue Property="PreparationAction" String="OrdersService.draftPrepare"/>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="OrdersService.OrderItems/ID">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+                <Annotation Term="Core.ComputedDefaultValue" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.OrderItems/order">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.OrderItems/order_ID">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.OrderItems/quantity">
+                <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
+            </Annotations>
+            <Annotations Target="OrdersService.OrderItems/IsActiveEntity">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.OrderItems/HasActiveEntity">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.OrderItems/HasDraftEntity">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.OrderItems/DraftAdministrativeData">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.OrderItemsInfo">
+                <Annotation Term="UI.LineItem">
+                    <Collection>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="comment"/>
+                            <PropertyValue Property="Label" String="comment"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.Identification">
+                    <Collection>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="comment"/>
+                            <PropertyValue Property="Label" String="Comment"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.Facets">
+                    <Collection>
+                        <Record Type="UI.ReferenceFacet">
+                            <PropertyValue Property="Label" String="OrderItemsInfo"/>
+                            <PropertyValue Property="Target" AnnotationPath="@UI.Identification"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="OrdersService.EntityContainer/OrderItemsInfo">
+                <Annotation Term="Common.DraftNode">
+                    <Record Type="Common.DraftNodeType">
+                        <PropertyValue Property="PreparationAction" String="OrdersService.draftPrepare"/>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="OrdersService.OrderItemsInfo/ID">
+                <Annotation Term="Core.ComputedDefaultValue" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.OrderItemsInfo/IsActiveEntity">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.OrderItemsInfo/HasActiveEntity">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.OrderItemsInfo/HasDraftEntity">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.OrderItemsInfo/DraftAdministrativeData">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.OrdersND">
+                <Annotation Term="UI.SelectionFields">
+                    <Collection>
+                        <PropertyPath>createdBy</PropertyPath>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.LineItem">
+                    <Collection>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="OrderNo"/>
+                            <PropertyValue Property="Label" String="OrderNo"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="buyer"/>
+                            <PropertyValue Property="Label" String="Customer"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="currency/symbol"/>
+                            <PropertyValue Property="Label" String="Currency"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="createdAt"/>
+                            <PropertyValue Property="Label" String="Date"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.HeaderInfo">
+                    <Record Type="UI.HeaderInfoType">
+                        <PropertyValue Property="TypeName" String="Order"/>
+                        <PropertyValue Property="TypeNamePlural" String="Orders"/>
+                        <PropertyValue Property="Title">
+                            <Record Type="UI.DataField">
+                                <PropertyValue Property="Label" String="OrderNo"/>
+                                <PropertyValue Property="Value" Path="OrderNo"/>
+                            </Record>
+                        </PropertyValue>
+                        <PropertyValue Property="Description">
+                            <Record Type="UI.DataField">
+                                <PropertyValue Property="Value" Path="createdBy"/>
+                            </Record>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="UI.Identification">
+                    <Collection>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="createdBy"/>
+                            <PropertyValue Property="Label" String="Customer"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="createdAt"/>
+                            <PropertyValue Property="Label" String="Date"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="OrderNo"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.HeaderFacets">
+                    <Collection>
+                        <Record Type="UI.ReferenceFacet">
+                            <PropertyValue Property="Label" String="Created"/>
+                            <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#Created"/>
+                        </Record>
+                        <Record Type="UI.ReferenceFacet">
+                            <PropertyValue Property="Label" String="Modified"/>
+                            <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#Modified"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.Facets">
+                    <Collection>
+                        <Record Type="UI.ReferenceFacet">
+                            <PropertyValue Property="Label" String="Details"/>
+                            <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#Details"/>
+                        </Record>
+                        <Record Type="UI.ReferenceFacet">
+                            <PropertyValue Property="Label" String="OrderItems"/>
+                            <PropertyValue Property="Target" AnnotationPath="Items/@UI.LineItem"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.FieldGroup" Qualifier="Details">
+                    <Record Type="UI.FieldGroupType">
+                        <PropertyValue Property="Data">
+                            <Collection>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="currency/code"/>
+                                    <PropertyValue Property="Label" String="Currency"/>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="UI.FieldGroup" Qualifier="Created">
+                    <Record Type="UI.FieldGroupType">
+                        <PropertyValue Property="Data">
+                            <Collection>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="createdBy"/>
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="createdAt"/>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="UI.FieldGroup" Qualifier="Modified">
+                    <Record Type="UI.FieldGroupType">
+                        <PropertyValue Property="Data">
+                            <Collection>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="modifiedBy"/>
+                                </Record>
+                                <Record Type="UI.DataField">
+                                    <PropertyValue Property="Value" Path="modifiedAt"/>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="OrdersService.OrdersND/ID">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+                <Annotation Term="Core.ComputedDefaultValue" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.OrdersND/createdAt">
+                <Annotation Term="UI.HiddenFilter" Bool="false"/>
+                <Annotation Term="UI.ExcludeFromNavigationContext" Bool="true"/>
+                <Annotation Term="Core.Immutable" Bool="true"/>
+                <Annotation Term="Core.Computed" Bool="true"/>
+                <Annotation Term="Common.Label" String="Created On"/>
+            </Annotations>
+            <Annotations Target="OrdersService.OrdersND/createdBy">
+                <Annotation Term="UI.HiddenFilter" Bool="false"/>
+                <Annotation Term="UI.ExcludeFromNavigationContext" Bool="true"/>
+                <Annotation Term="Core.Immutable" Bool="true"/>
+                <Annotation Term="Core.Computed" Bool="true"/>
+                <Annotation Term="Core.Description" String="User's unique ID"/>
+                <Annotation Term="Common.Label" String="Created By"/>
+            </Annotations>
+            <Annotations Target="OrdersService.OrdersND/modifiedAt">
+                <Annotation Term="UI.HiddenFilter" Bool="true"/>
+                <Annotation Term="UI.ExcludeFromNavigationContext" Bool="true"/>
+                <Annotation Term="Core.Computed" Bool="true"/>
+                <Annotation Term="Common.Label" String="Changed On"/>
+            </Annotations>
+            <Annotations Target="OrdersService.OrdersND/modifiedBy">
+                <Annotation Term="UI.HiddenFilter" Bool="true"/>
+                <Annotation Term="UI.ExcludeFromNavigationContext" Bool="true"/>
+                <Annotation Term="Core.Computed" Bool="true"/>
+                <Annotation Term="Core.Description" String="User's unique ID"/>
+                <Annotation Term="Common.Label" String="Changed By"/>
+            </Annotations>
+            <Annotations Target="OrdersService.OrdersND/OrderNo">
+                <Annotation Term="Common.Label" String="Order Number"/>
+            </Annotations>
+            <Annotations Target="OrdersService.OrdersND/buyer">
+                <Annotation Term="Common.Label" String="User ID"/>
+                <Annotation Term="Core.Description" String="User's unique ID"/>
+            </Annotations>
+            <Annotations Target="OrdersService.OrdersND/currency">
+                <Annotation Term="Common.Label" String="Currency"/>
+                <Annotation Term="Core.Description" String="Currency code as specified by ISO 4217"/>
+            </Annotations>
+            <Annotations Target="OrdersService.OrdersND/currency_code">
+                <Annotation Term="Common.Label" String="Currency"/>
+                <Annotation Term="Common.ValueList">
+                    <Record Type="Common.ValueListType">
+                        <PropertyValue Property="Label" String="Currency"/>
+                        <PropertyValue Property="CollectionPath" String="Currencies"/>
+                        <PropertyValue Property="Parameters">
+                            <Collection>
+                                <Record Type="Common.ValueListParameterInOut">
+                                    <PropertyValue Property="LocalDataProperty" PropertyPath="currency_code"/>
+                                    <PropertyValue Property="ValueListProperty" String="code"/>
+                                </Record>
+                                <Record Type="Common.ValueListParameterDisplayOnly">
+                                    <PropertyValue Property="ValueListProperty" String="name"/>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="Core.Description" String="Currency code as specified by ISO 4217"/>
+            </Annotations>
+            <Annotations Target="OrdersService.OrderItemsND">
+                <Annotation Term="UI.LineItem">
+                    <Collection>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="product_ID"/>
+                            <PropertyValue Property="Label" String="ID"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="title"/>
+                            <PropertyValue Property="Label" String="ProductTitle"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="price"/>
+                            <PropertyValue Property="Label" String="UnitPrice"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="quantity"/>
+                            <PropertyValue Property="Label" String="Quantity"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="validFrom"/>
+                            <PropertyValue Property="Label" String="validFrom"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="timestamp"/>
+                            <PropertyValue Property="Label" String="timestamp"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="date"/>
+                            <PropertyValue Property="Label" String="date"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="time"/>
+                            <PropertyValue Property="Label" String="time"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.Identification">
+                    <Collection>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="quantity"/>
+                            <PropertyValue Property="Label" String="Quantity"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="title"/>
+                            <PropertyValue Property="Label" String="Product"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="price"/>
+                            <PropertyValue Property="Label" String="UnitPrice"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="validFrom"/>
+                            <PropertyValue Property="Label" String="validFrom"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="timestamp"/>
+                            <PropertyValue Property="Label" String="timestamp"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="date"/>
+                            <PropertyValue Property="Label" String="date"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="time"/>
+                            <PropertyValue Property="Label" String="time"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.Facets">
+                    <Collection>
+                        <Record Type="UI.ReferenceFacet">
+                            <PropertyValue Property="Label" String="OrderItems"/>
+                            <PropertyValue Property="Target" AnnotationPath="@UI.Identification"/>
+                        </Record>
+                        <Record Type="UI.ReferenceFacet">
+                            <PropertyValue Property="Label" String="OrderItems"/>
+                            <PropertyValue Property="Target" AnnotationPath="Infos/@UI.LineItem"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="OrdersService.OrderItemsND/ID">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+                <Annotation Term="Core.ComputedDefaultValue" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.OrderItemsND/order">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.OrderItemsND/order_ID">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.OrderItemsND/quantity">
+                <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory"/>
+            </Annotations>
+            <Annotations Target="OrdersService.OrderItemsInfoND">
+                <Annotation Term="UI.LineItem">
+                    <Collection>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="comment"/>
+                            <PropertyValue Property="Label" String="comment"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.Identification">
+                    <Collection>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="comment"/>
+                            <PropertyValue Property="Label" String="Comment"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.Facets">
+                    <Collection>
+                        <Record Type="UI.ReferenceFacet">
+                            <PropertyValue Property="Label" String="OrderItemsInfo"/>
+                            <PropertyValue Property="Target" AnnotationPath="@UI.Identification"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="OrdersService.OrderItemsInfoND/ID">
+                <Annotation Term="Core.ComputedDefaultValue" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.ShippingDetails">
+                <Annotation Term="UI.LineItem">
+                    <Collection>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="order_ID"/>
+                            <PropertyValue Property="Label" String="ID"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="address"/>
+                            <PropertyValue Property="Label" String="address"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="city"/>
+                            <PropertyValue Property="Label" String="city"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="state"/>
+                            <PropertyValue Property="Label" String="state"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="country"/>
+                            <PropertyValue Property="Label" String="country"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="shipmentDate"/>
+                            <PropertyValue Property="Label" String="shipmentDate"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="arrivalDate"/>
+                            <PropertyValue Property="Label" String="arrivalDate"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.Identification">
+                    <Collection>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="address"/>
+                            <PropertyValue Property="Label" String="address"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="city"/>
+                            <PropertyValue Property="Label" String="city"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="state"/>
+                            <PropertyValue Property="Label" String="state"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="country"/>
+                            <PropertyValue Property="Label" String="country"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="shipmentDate"/>
+                            <PropertyValue Property="Label" String="shipmentDate"/>
+                        </Record>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="arrivalDate"/>
+                            <PropertyValue Property="Label" String="arrivalDate"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="UI.Facets">
+                    <Collection>
+                        <Record Type="UI.ReferenceFacet">
+                            <PropertyValue Property="Label" String="OrderItems"/>
+                            <PropertyValue Property="Target" AnnotationPath="@UI.Identification"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="OrdersService.EntityContainer/ShippingDetails">
+                <Annotation Term="Common.DraftNode">
+                    <Record Type="Common.DraftNodeType">
+                        <PropertyValue Property="PreparationAction" String="OrdersService.draftPrepare"/>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="OrdersService.ShippingDetails/ID">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+                <Annotation Term="Core.ComputedDefaultValue" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.ShippingDetails/order">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.ShippingDetails/order_ID">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.ShippingDetails/IsActiveEntity">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.ShippingDetails/HasActiveEntity">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.ShippingDetails/HasDraftEntity">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.ShippingDetails/DraftAdministrativeData">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.Currencies">
+                <Annotation Term="UI.Identification">
+                    <Collection>
+                        <Record Type="UI.DataField">
+                            <PropertyValue Property="Value" Path="name"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="OrdersService.Currencies/name">
+                <Annotation Term="Common.Label" String="Name"/>
+            </Annotations>
+            <Annotations Target="OrdersService.Currencies/descr">
+                <Annotation Term="Common.Label" String="Description"/>
+            </Annotations>
+            <Annotations Target="OrdersService.Currencies/code">
+                <Annotation Term="Common.Text" Path="name"/>
+                <Annotation Term="Common.Label" String="Currency Code"/>
+            </Annotations>
+            <Annotations Target="OrdersService.Currencies/symbol">
+                <Annotation Term="Common.Label" String="Currency Symbol"/>
+            </Annotations>
+            <Annotations Target="OrdersService.Currencies/minorUnit">
+                <Annotation Term="Common.Label" String="Currency Minor Unit Fractions"/>
+            </Annotations>
+            <Annotations Target="OrdersService.DraftAdministrativeData">
+                <Annotation Term="Common.Label" String="Draft Administrative Data"/>
+            </Annotations>
+            <Annotations Target="OrdersService.DraftAdministrativeData/DraftUUID">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+                <Annotation Term="Common.Label" String="Draft (Technical ID)"/>
+                <Annotation Term="Core.ComputedDefaultValue" Bool="true"/>
+            </Annotations>
+            <Annotations Target="OrdersService.DraftAdministrativeData/CreationDateTime">
+                <Annotation Term="Common.Label" String="Draft Created On"/>
+            </Annotations>
+            <Annotations Target="OrdersService.DraftAdministrativeData/CreatedByUser">
+                <Annotation Term="Common.Label" String="Draft Created By"/>
+            </Annotations>
+            <Annotations Target="OrdersService.DraftAdministrativeData/DraftIsCreatedByMe">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+                <Annotation Term="Common.Label" String="Draft Created By Me"/>
+            </Annotations>
+            <Annotations Target="OrdersService.DraftAdministrativeData/LastChangeDateTime">
+                <Annotation Term="Common.Label" String="Draft Last Changed On"/>
+            </Annotations>
+            <Annotations Target="OrdersService.DraftAdministrativeData/LastChangedByUser">
+                <Annotation Term="Common.Label" String="Draft Last Changed By"/>
+            </Annotations>
+            <Annotations Target="OrdersService.DraftAdministrativeData/InProcessByUser">
+                <Annotation Term="Common.Label" String="Draft In Process By"/>
+            </Annotations>
+            <Annotations Target="OrdersService.DraftAdministrativeData/DraftIsProcessedByMe">
+                <Annotation Term="UI.Hidden" Bool="true"/>
+                <Annotation Term="Common.Label" String="Draft In Process By Me"/>
+            </Annotations>
+            <Annotations Target="OrdersService.Currencies_texts/locale">
+                <Annotation Term="Common.Label" String="Language Code"/>
+            </Annotations>
+            <Annotations Target="OrdersService.Currencies_texts/name">
+                <Annotation Term="Common.Label" String="Name"/>
+            </Annotations>
+            <Annotations Target="OrdersService.Currencies_texts/descr">
+                <Annotation Term="Common.Label" String="Description"/>
+            </Annotations>
+            <Annotations Target="OrdersService.Currencies_texts/code">
+                <Annotation Term="Common.Text" Path="name"/>
+                <Annotation Term="Common.Label" String="Currency Code"/>
+            </Annotations>
+        </Schema>
+    </edmx:DataServices>
+</edmx:Edmx>

--- a/examples/packages/ordersv4freestyle/webapp/manifest.json
+++ b/examples/packages/ordersv4freestyle/webapp/manifest.json
@@ -44,7 +44,7 @@
     }
   },
   "sap.ui5": {
-    "flexEnabled": true,
+    "flexEnabled": false,
     "dependencies": {
       "minUI5Version": "1.120.24",
       "libs": {
@@ -56,6 +56,9 @@
         "sap.ui.generic.app": {},
         "sap.ui.table": {},
         "sap.ushell": {}
+      },
+      "components": {
+        "cc.spreadsheetimporter.v1_4_3": {}
       }
     },
     "contentDensities": {
@@ -86,6 +89,14 @@
           "uri": "css/style.css"
         }
       ]
+    },
+    "componentUsages": {
+      "spreadsheetImporter": {
+        "name": "cc.spreadsheetimporter.v1_4_3"
+      }
+    },
+    "resourceRoots": {
+      "cc.spreadsheetimporter.v1_4_3": "./thirdparty/customcontrol/spreadsheetimporter/v1_4_3"
     },
     "routing": {
       "config": {

--- a/examples/packages/ordersv4freestyle/webapp/manifest.json
+++ b/examples/packages/ordersv4freestyle/webapp/manifest.json
@@ -1,0 +1,126 @@
+{
+  "_version": "1.59.0",
+  "sap.app": {
+    "id": "ordersv4freestyle",
+    "type": "application",
+    "i18n": "i18n/i18n.properties",
+    "applicationVersion": {
+      "version": "0.0.1"
+    },
+    "title": "{{appTitle}}",
+    "description": "{{appDescription}}",
+    "resources": "resources.json",
+    "sourceTemplate": {
+      "id": "@sap/generator-fiori:basic",
+      "version": "1.12.4",
+      "toolsId": "8eb2f553-2b99-4849-a4c4-0ae9a05ce5d3"
+    },
+    "dataSources": {
+      "mainService": {
+        "uri": "/odata/v4/Orders/",
+        "type": "OData",
+        "settings": {
+          "annotations": [],
+          "localUri": "localService/metadata.xml",
+          "odataVersion": "4.0"
+        }
+      }
+    }
+  },
+  "sap.ui": {
+    "technology": "UI5",
+    "icons": {
+      "icon": "",
+      "favIcon": "",
+      "phone": "",
+      "phone@2": "",
+      "tablet": "",
+      "tablet@2": ""
+    },
+    "deviceTypes": {
+      "desktop": true,
+      "tablet": true,
+      "phone": true
+    }
+  },
+  "sap.ui5": {
+    "flexEnabled": true,
+    "dependencies": {
+      "minUI5Version": "1.120.24",
+      "libs": {
+        "sap.m": {},
+        "sap.ui.core": {},
+        "sap.f": {},
+        "sap.suite.ui.generic.template": {},
+        "sap.ui.comp": {},
+        "sap.ui.generic.app": {},
+        "sap.ui.table": {},
+        "sap.ushell": {}
+      }
+    },
+    "contentDensities": {
+      "compact": true,
+      "cozy": true
+    },
+    "models": {
+      "i18n": {
+        "type": "sap.ui.model.resource.ResourceModel",
+        "settings": {
+          "bundleName": "ordersv4freestyle.i18n.i18n"
+        }
+      },
+      "": {
+        "dataSource": "mainService",
+        "preload": true,
+        "settings": {
+          "synchronizationMode": "None",
+          "operationMode": "Server",
+          "autoExpandSelect": true,
+          "earlyRequests": true
+        }
+      }
+    },
+    "resources": {
+      "css": [
+        {
+          "uri": "css/style.css"
+        }
+      ]
+    },
+    "routing": {
+      "config": {
+        "routerClass": "sap.m.routing.Router",
+        "viewType": "XML",
+        "async": true,
+        "viewPath": "ordersv4freestyle.view",
+        "controlAggregation": "pages",
+        "controlId": "app",
+        "clearControlAggregation": false
+      },
+      "routes": [
+        {
+          "name": "RouteMainView",
+          "pattern": ":?query:",
+          "target": [
+            "TargetMainView"
+          ]
+        }
+      ],
+      "targets": {
+        "TargetMainView": {
+          "viewType": "XML",
+          "transition": "slide",
+          "clearControlAggregation": false,
+          "viewId": "MainView",
+          "viewName": "MainView"
+        }
+      }
+    },
+    "rootView": {
+      "viewName": "ordersv4freestyle.view.App",
+      "type": "XML",
+      "async": true,
+      "id": "App"
+    }
+  }
+}

--- a/examples/packages/ordersv4freestyle/webapp/model/models.js
+++ b/examples/packages/ordersv4freestyle/webapp/model/models.js
@@ -1,0 +1,23 @@
+sap.ui.define([
+    "sap/ui/model/json/JSONModel",
+    "sap/ui/Device"
+], 
+    /**
+     * provide app-view type models (as in the first "V" in MVVC)
+     * 
+     * @param {typeof sap.ui.model.json.JSONModel} JSONModel
+     * @param {typeof sap.ui.Device} Device
+     * 
+     * @returns {Function} createDeviceModel() for providing runtime info for the device the UI5 app is running on
+     */
+    function (JSONModel, Device) {
+        "use strict";
+
+        return {
+            createDeviceModel: function () {
+                var oModel = new JSONModel(Device);
+                oModel.setDefaultBindingMode("OneWay");
+                return oModel;
+        }
+    };
+});

--- a/examples/packages/ordersv4freestyle/webapp/test/flpSandbox.html
+++ b/examples/packages/ordersv4freestyle/webapp/test/flpSandbox.html
@@ -1,0 +1,80 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<!-- Copyright (c) 2015 SAP AG, All Rights Reserved -->
+<head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{appTitle}}</title>
+
+    <!-- Bootstrap the unified shell in sandbox mode for standalone usage.
+
+         The renderer is specified in the global Unified Shell configuration object "sap-ushell-config".
+
+         The fiori2 renderer will render the shell header allowing, for instance,
+         testing of additional application setting buttons.
+
+         The navigation target resolution service is configured in a way that the empty URL hash is
+         resolved to our own application.
+
+         This example uses relative path references for the SAPUI5 resources and test-resources;
+         it might be necessary to adapt them depending on the target runtime platform.
+         The sandbox platform is restricted to development or demo use cases and must NOT be used
+         for productive scenarios.
+    -->
+    <script type="text/javascript">
+        window["sap-ushell-config"] = {
+            defaultRenderer: "fiori2",
+            bootstrapPlugins: {
+                "RuntimeAuthoringPlugin": {
+                    component: "sap.ushell.plugins.rta",
+                    config: {
+                        validateAppVersion: false
+                    }
+                }
+            },
+            renderers: {
+                fiori2: {
+                    componentData: {
+                        config: {
+                            search: "hidden",
+                            enableSearch: false
+                        }
+                    }
+                }
+            },
+            applications: {
+                "ordersv4freestyle-display": {
+                    title: "OrdersV4 Freestyle 120",
+                    description: "An SAP Fiori application.",
+                    additionalInformation: "SAPUI5.Component=ordersv4freestyle",
+                    applicationType: "URL",
+                    url: "../"
+                }
+            }
+        };
+    </script>
+
+    <script src="../test-resources/sap/ushell/bootstrap/sandbox.js" id="sap-ushell-bootstrap"></script>
+    <!-- Bootstrap the UI5 core library. 'data-sap-ui-frameOptions="allow"'' is a NON-SECURE setting for test environments -->
+    <script id="sap-ui-bootstrap"
+        src="../resources/sap-ui-core.js"
+        data-sap-ui-libs="sap.m,sap.ui.core,sap.f,sap.suite.ui.generic.template,sap.ui.comp,sap.ui.generic.app,sap.ui.table,sap.ushell"
+        data-sap-ui-async="true"
+        data-sap-ui-preload="async"
+        data-sap-ui-theme="sap_horizon"
+        data-sap-ui-compatVersion="edge"
+        data-sap-ui-language="en"
+        data-sap-ui-resourceroots='{"ordersv4freestyle": "../"}'
+        data-sap-ui-frameOptions="allow">
+    </script>
+    <script id="locate-reuse-libs" src="./locate-reuse-libs.js" data-sap-ui-manifest-uri="../manifest.json">
+    </script>
+</head>
+
+<!-- UI Content -->
+
+<body class="sapUiBody" id="content">
+</body>
+
+</html>

--- a/examples/packages/ordersv4freestyle/webapp/test/flpSandbox.js
+++ b/examples/packages/ordersv4freestyle/webapp/test/flpSandbox.js
@@ -1,0 +1,100 @@
+sap.ui.define([
+	"sap/base/util/ObjectPath",
+	"sap/ushell/services/Container"
+], function (ObjectPath) {
+	"use strict";
+
+	// define ushell config
+	ObjectPath.set(["sap-ushell-config"], {
+		defaultRenderer: "fiori2",
+		bootstrapPlugins: {
+			"RuntimeAuthoringPlugin": {
+				component: "sap.ushell.plugins.rta",
+				config: {
+					validateAppVersion: false
+				}
+			},
+			"PersonalizePlugin": {
+				component: "sap.ushell.plugins.rta-personalize",
+				config: {
+					validateAppVersion: false
+				}
+			}
+		},
+		renderers: {
+			fiori2: {
+				componentData: {
+					config: {
+						enableSearch: false,
+						rootIntent: "Shell-home"
+					}
+				}
+			}
+		},
+		services: {
+			"LaunchPage": {
+				"adapter": {
+					"config": {
+						"groups": [{
+							"tiles": [{
+								"tileType": "sap.ushell.ui.tile.StaticTile",
+								"properties": {
+									"title": "OrdersV4 Freestyle 120",
+									"targetURL": "#ordersv4freestyle-display"
+								}
+							}]
+						}]
+					}
+				}
+			},
+			"ClientSideTargetResolution": {
+				"adapter": {
+					"config": {
+						"inbounds": {
+							"ordersv4freestyle-display": {
+								"semanticObject": "ordersv4freestyle",
+								"action": "display",
+								"description": "An SAP Fiori application.",
+								"title": "OrdersV4 Freestyle 120",
+								"signature": {
+									"parameters": {}
+								},
+								"resolutionResult": {
+									"applicationType": "SAPUI5",
+									"additionalInformation": "SAPUI5.Component=ordersv4freestyle",
+									"url": sap.ui.require.toUrl("ordersv4freestyle")
+								}
+							}
+						}
+					}
+				}
+			},
+			NavTargetResolution: {
+				config: {
+					"enableClientSideTargetResolution": true
+				}
+			}
+		}
+	});
+
+	var oFlpSandbox = {
+		init: function () {
+			/**
+			 * Initializes the FLP sandbox
+			 * @returns {Promise} a promise that is resolved when the sandbox bootstrap has finshed
+			 */
+
+			// sandbox is a singleton, so we can start it only once
+			if (!this._oBootstrapFinished) {
+				this._oBootstrapFinished = sap.ushell.bootstrap("local");
+				this._oBootstrapFinished.then(function () {
+					sap.ushell.Container.createRenderer().placeAt("content");
+				});
+			}
+
+			return this._oBootstrapFinished;
+		}
+	};
+
+	return oFlpSandbox;
+});

--- a/examples/packages/ordersv4freestyle/webapp/test/initFlpSandbox.js
+++ b/examples/packages/ordersv4freestyle/webapp/test/initFlpSandbox.js
@@ -1,0 +1,13 @@
+sap.ui.define([
+	"./flpSandbox",
+	"sap/ui/fl/FakeLrepConnectorLocalStorage",
+	"sap/m/MessageBox"
+], function (flpSandbox, FakeLrepConnectorLocalStorage, MessageBox) {
+	"use strict";
+
+	flpSandbox.init().then(function () {
+		FakeLrepConnectorLocalStorage.enableFakeConnector();
+	}, function (oError) {
+		MessageBox.error(oError.message);
+	});
+});

--- a/examples/packages/ordersv4freestyle/webapp/test/integration/AllJourneys.js
+++ b/examples/packages/ordersv4freestyle/webapp/test/integration/AllJourneys.js
@@ -1,0 +1,13 @@
+sap.ui.define([
+	"sap/ui/test/Opa5",
+	"./arrangements/Startup",
+	"./NavigationJourney"
+], function (Opa5, Startup) {
+	"use strict";
+
+	Opa5.extendConfig({
+		arrangements: new Startup(),
+		viewNamespace: "ordersv4freestyle.view.",
+		autoWait: true
+	});
+});

--- a/examples/packages/ordersv4freestyle/webapp/test/integration/NavigationJourney.js
+++ b/examples/packages/ordersv4freestyle/webapp/test/integration/NavigationJourney.js
@@ -1,0 +1,23 @@
+/*global QUnit*/
+
+sap.ui.define([
+	"sap/ui/test/opaQunit",
+	"./pages/App",
+	"./pages/MainView"
+], function (opaTest) {
+	"use strict";
+
+	QUnit.module("Navigation Journey");
+
+	opaTest("Should see the initial page of the app", function (Given, When, Then) {
+		// Arrangements
+		Given.iStartMyApp();
+
+		// Assertions
+		Then.onTheAppPage.iShouldSeeTheApp();
+      	Then.onTheViewPage.iShouldSeeThePageView();
+
+		//Cleanup
+		Then.iTeardownMyApp();
+	});
+});

--- a/examples/packages/ordersv4freestyle/webapp/test/integration/arrangements/Startup.js
+++ b/examples/packages/ordersv4freestyle/webapp/test/integration/arrangements/Startup.js
@@ -1,0 +1,25 @@
+sap.ui.define([
+	"sap/ui/test/Opa5"
+], function (Opa5) {
+	"use strict";
+
+	return Opa5.extend("integration.arrangements.Startup", {
+
+		iStartMyApp: function (oOptionsParameter) {
+			var oOptions = oOptionsParameter || {};
+
+			// start the app with a minimal delay to make tests fast but still async to discover basic timing issues
+			oOptions.delay = oOptions.delay || 50;
+
+			// start the app UI component
+			this.iStartMyUIComponent({
+				componentConfig: {
+					name: "ordersv4freestyle",
+					async: true
+				},
+				hash: oOptions.hash,
+				autoWait: oOptions.autoWait
+			});
+		}
+	});
+});

--- a/examples/packages/ordersv4freestyle/webapp/test/integration/opaTests.qunit.html
+++ b/examples/packages/ordersv4freestyle/webapp/test/integration/opaTests.qunit.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8" />
+	<title>Integration tests for Basic Template</title>
+
+	<script
+		id="sap-ui-bootstrap"
+		src="../../resources/sap-ui-core.js"
+		data-sap-ui-theme="sap_horizon"
+		data-sap-ui-resourceroots='{
+			"ordersv4freestyle": "../../",
+			"integration": "./"
+		}'
+		data-sap-ui-animation="false"
+		data-sap-ui-compatVersion="edge"
+		data-sap-ui-async="true"
+		data-sap-ui-preload="async"
+		data-sap-ui-oninit="module:integration/opaTests.qunit">
+	</script>
+	<link rel="stylesheet" type="text/css" href="../../resources/sap/ui/thirdparty/qunit-2.css">
+	<script src="../../resources/sap/ui/thirdparty/qunit-2.js"></script>
+	<script src="../../resources/sap/ui/qunit/qunit-junit.js"></script>
+</head>
+<body>
+	<div id="qunit"></div>
+	<div id="qunit-fixture"></div>
+</body>
+</html>

--- a/examples/packages/ordersv4freestyle/webapp/test/integration/opaTests.qunit.js
+++ b/examples/packages/ordersv4freestyle/webapp/test/integration/opaTests.qunit.js
@@ -1,0 +1,7 @@
+/* global QUnit */
+
+sap.ui.require(["ordersv4freestyle/test/integration/AllJourneys"
+], function () {
+	QUnit.config.autostart = false;
+	QUnit.start();
+});

--- a/examples/packages/ordersv4freestyle/webapp/test/integration/pages/App.js
+++ b/examples/packages/ordersv4freestyle/webapp/test/integration/pages/App.js
@@ -1,0 +1,28 @@
+sap.ui.define([
+	"sap/ui/test/Opa5"
+], function (Opa5) {
+	"use strict";
+	var sViewName = "App";
+	
+	Opa5.createPageObjects({
+		onTheAppPage: {
+
+			actions: {},
+
+			assertions: {
+
+				iShouldSeeTheApp: function () {
+					return this.waitFor({
+						id: "app",
+						viewName: sViewName,
+						success: function () {
+							Opa5.assert.ok(true, "The " + sViewName + " view is displayed");
+						},
+						errorMessage: "Did not find the " + sViewName + " view"
+					});
+				}
+			}
+		}
+	});
+
+});

--- a/examples/packages/ordersv4freestyle/webapp/test/integration/pages/MainView.js
+++ b/examples/packages/ordersv4freestyle/webapp/test/integration/pages/MainView.js
@@ -1,0 +1,28 @@
+sap.ui.define([
+	"sap/ui/test/Opa5"
+], function (Opa5) {
+	"use strict";
+	var sViewName = "MainView";
+	
+	Opa5.createPageObjects({
+		onTheViewPage: {
+
+			actions: {},
+
+			assertions: {
+
+				iShouldSeeThePageView: function () {
+					return this.waitFor({
+						id: "page",
+						viewName: sViewName,
+						success: function () {
+							Opa5.assert.ok(true, "The " + sViewName + " view is displayed");
+						},
+						errorMessage: "Did not find the " + sViewName + " view"
+					});
+				}
+			}
+		}
+	});
+
+});

--- a/examples/packages/ordersv4freestyle/webapp/test/locate-reuse-libs.js
+++ b/examples/packages/ordersv4freestyle/webapp/test/locate-reuse-libs.js
@@ -1,0 +1,217 @@
+(function (sap) {
+    var fioriToolsGetManifestLibs = function (manifestPath) {
+        var url = manifestPath;
+        var result = "";
+        // SAPUI5 delivered namespaces from https://ui5.sap.com/#/api/sap
+        var ui5Libs = [
+            "sap.apf",
+            "sap.base",
+            "sap.chart",
+            "sap.collaboration",
+            "sap.f",
+            "sap.fe",
+            "sap.fileviewer",
+            "sap.gantt",
+            "sap.landvisz",
+            "sap.m",
+            "sap.ndc",
+            "sap.ovp",
+            "sap.rules",
+            "sap.suite",
+            "sap.tnt",
+            "sap.ui",
+            "sap.uiext",
+            "sap.ushell",
+            "sap.uxap",
+            "sap.viz",
+            "sap.webanalytics",
+            "sap.zen"
+        ];
+        function getKeys(libOrComp, libOrCompKeysString) {
+            var libOrCompKeysStringTmp = libOrCompKeysString;
+            Object.keys(libOrComp).forEach(function (libOrCompKey) {
+                // ignore libs or Components that start with SAPUI5 delivered namespaces
+                if (!ui5Libs.some(function (substring) { return libOrCompKey === substring || libOrCompKey.startsWith(substring + "."); })) {
+                    if (libOrCompKeysStringTmp.length > 0) {
+                        libOrCompKeysStringTmp = libOrCompKeysStringTmp + "," + libOrCompKey;
+                    } else {
+                        libOrCompKeysStringTmp = libOrCompKey;
+                    }
+                }
+            });
+            return libOrCompKeysStringTmp;
+        }
+        return new Promise(function (resolve, reject) {
+            $.ajax(url)
+                .done(function (manifest) {
+                    if (manifest) {
+                        if (
+                            manifest["sap.ui5"] &&
+                            manifest["sap.ui5"].dependencies
+                        ) {
+                            if (manifest["sap.ui5"].dependencies.libs) {
+                                result = getKeys(manifest["sap.ui5"].dependencies.libs, result);
+                            }
+                            if (manifest["sap.ui5"].dependencies.components) {
+                                result = getKeys(manifest["sap.ui5"].dependencies.components, result);
+                            }
+                        }
+                        if (
+                            manifest["sap.ui5"] &&
+                            manifest["sap.ui5"].componentUsages
+                        ) {
+                            result = getKeys(manifest["sap.ui5"].componentUsages, result);
+                        }
+                    }
+                    resolve(result);
+                })
+                .fail(function () {
+                    reject(new Error("Could not fetch manifest at '" + manifestPath));
+                });
+        });
+    };
+    function registerModules(dataFromAppIndex) {
+        Object.keys(dataFromAppIndex).forEach(function (moduleDefinitionKey) {
+            var moduleDefinition = dataFromAppIndex[moduleDefinitionKey];
+            if (moduleDefinition && moduleDefinition.dependencies) {
+                moduleDefinition.dependencies.forEach(function (dependency) {
+                    if (dependency.url && dependency.url.length > 0 && dependency.type === "UI5LIB") {
+                        sap.ui.require(["sap/base/Log"], function (Log) {
+                            Log.info("Registering Library " +
+                                dependency.componentId +
+                                " from server " +
+                                dependency.url);
+                        });
+                        var compId = dependency.componentId.replace(/\./g, "/");
+                        var config = {
+                            paths: {
+                            }
+                        };
+                        config.paths[compId] = dependency.url;
+                        sap.ui.loader.config(config);
+                    }
+                });
+            }
+        });
+    }
+    /**
+     * Registers the module paths for dependencies of the given component.
+     * @param {string} manifestPath The the path to the app manifest path
+     * for which the dependencies should be registered.
+     * @returns {Promise} A promise which is resolved when the ajax request for
+     * the app-index was successful and the module paths were registered.
+     */
+    sap.registerComponentDependencyPaths = function (manifestPath) {
+
+        return fioriToolsGetManifestLibs(manifestPath).then(function (libs) {
+            if (libs && libs.length > 0) {
+                var url = "/sap/bc/ui2/app_index/ui5_app_info?id=" + libs;
+                var sapClient = "";
+
+                return new Promise(
+                    function (resolve) {
+                        sap.ui.require(["sap/base/util/UriParameters"], function (UriParameters) {
+                            sapClient = UriParameters.fromQuery(window.location.search).get("sap-client");
+                            if (sapClient && sapClient.length === 3) {
+                                url = url + "&sap-client=" + sapClient;
+                            }
+                            resolve(url);
+                        });
+                    }).then(function (url2) {
+                        return $.ajax(url2).done(function (data) {
+                            if (data) {
+                                registerModules(data);
+                            }
+                        });
+                    });
+            } else {
+                return undefined;
+            }
+        });
+    };
+})(sap);
+
+function registerSAPFonts() {  
+    sap.ui.require(["sap/ui/core/IconPool"], function (IconPool) {  
+    //Fiori Theme font family and URI
+    var fioriTheme = {
+        fontFamily: "SAP-icons-TNT",
+        fontURI: sap.ui.require.toUrl("sap/tnt/themes/base/fonts/")
+    };
+    //Registering to the icon pool
+    IconPool.registerFont(fioriTheme);
+    //SAP Business Suite Theme font family and URI
+    var bSuiteTheme = {
+        fontFamily: "BusinessSuiteInAppSymbols",
+        fontURI: sap.ui.require.toUrl("sap/ushell/themes/base/fonts/")
+    };
+    //Registering to the icon pool
+    IconPool.registerFont(bSuiteTheme);
+    });
+}
+
+/*eslint-disable fiori-custom/sap-browser-api-warning, fiori-custom/sap-no-dom-access*/
+var currentScript = document.getElementById("locate-reuse-libs");
+if (!currentScript) {
+    currentScript = document.currentScript;
+}
+var manifestUri = currentScript.getAttribute("data-sap-ui-manifest-uri");
+var componentName = currentScript.getAttribute("data-sap-ui-componentName");
+var useMockserver = currentScript.getAttribute("data-sap-ui-use-mockserver");
+
+sap.registerComponentDependencyPaths(manifestUri)
+    .catch(function (error) {
+        sap.ui.require(["sap/base/Log"], function (Log) {
+            Log.error(error);
+        });
+    })
+    .finally(function () {
+
+        // setting the app title with internationalization 
+        sap.ui.getCore().attachInit(function () {
+            var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
+            sap.ui.require(["sap/base/i18n/ResourceBundle"], function (ResourceBundle) {
+                var oResourceBundle = ResourceBundle.create({
+                    url: "i18n/i18n.properties",
+                    locale: sLocale
+                });
+                document.title = oResourceBundle.getText("appTitle");
+            });
+        });
+
+        if (componentName && componentName.length > 0) {
+            if (useMockserver && useMockserver === "true") {
+                sap.ui.getCore().attachInit(function () {
+                    registerSAPFonts();
+                    sap.ui.require([componentName.replace(/\./g, "/") + "/localService/mockserver"], function (server) {
+                        // set up test service for local testing
+                        server.init();
+                        // initialize the ushell sandbox component
+                        sap.ushell.Container.createRenderer().placeAt("content");
+                    });
+                });
+            } else {
+                // Requiring the ComponentSupport module automatically executes the component initialisation for all declaratively defined components
+                sap.ui.require(["sap/ui/core/ComponentSupport"]);
+
+                // setting the app title with the i18n text 
+                sap.ui.getCore().attachInit(function () {
+                    registerSAPFonts();
+                    var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
+                    sap.ui.require(["sap/base/i18n/ResourceBundle"], function (ResourceBundle) {
+                        var oResourceBundle = ResourceBundle.create({
+                            url: "i18n/i18n.properties",
+                            locale: sLocale
+                        });
+                        document.title = oResourceBundle.getText("appTitle");
+                    });
+                });
+            }
+        } else {
+            sap.ui.getCore().attachInit(function () {
+                registerSAPFonts();
+                // initialize the ushell sandbox component
+                sap.ushell.Container.createRenderer().placeAt("content");
+            });
+        }
+    });

--- a/examples/packages/ordersv4freestyle/webapp/test/testsuite.qunit.html
+++ b/examples/packages/ordersv4freestyle/webapp/test/testsuite.qunit.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>
+            QUnit test suite for ordersv4freestyle
+        </title>
+        <script src="../resources/sap/ui/qunit/qunit-redirect.js"></script>
+        <script src="testsuite.qunit.js" data-sap-ui-testsuite></script>
+    </head>
+    <body></body>
+</html>

--- a/examples/packages/ordersv4freestyle/webapp/test/testsuite.qunit.js
+++ b/examples/packages/ordersv4freestyle/webapp/test/testsuite.qunit.js
@@ -1,0 +1,15 @@
+/* global window, parent, location */
+
+// eslint-disable-next-line fiori-custom/sap-no-global-define
+window.suite = function() {
+	"use strict";
+
+	// eslint-disable-next-line
+	var oSuite = new parent.jsUnitTestSuite(),
+		sContextPath = location.pathname.substring(0, location.pathname.lastIndexOf("/") + 1);
+
+	oSuite.addTestPage(sContextPath + "unit/unitTests.qunit.html");
+	oSuite.addTestPage(sContextPath + "integration/opaTests.qunit.html");
+
+	return oSuite;
+};

--- a/examples/packages/ordersv4freestyle/webapp/test/unit/AllTests.js
+++ b/examples/packages/ordersv4freestyle/webapp/test/unit/AllTests.js
@@ -1,0 +1,5 @@
+sap.ui.define([
+	"ordersv4freestyle/test/unit/controller/MainView.controller"
+], function () {
+	"use strict";
+});

--- a/examples/packages/ordersv4freestyle/webapp/test/unit/controller/MainView.controller.js
+++ b/examples/packages/ordersv4freestyle/webapp/test/unit/controller/MainView.controller.js
@@ -1,0 +1,16 @@
+/*global QUnit*/
+
+sap.ui.define([
+	"ordersv4freestyle/controller/MainView.controller"
+], function (Controller) {
+	"use strict";
+
+	QUnit.module("MainView Controller");
+
+	QUnit.test("I should test the MainView controller", function (assert) {
+		var oAppController = new Controller();
+		oAppController.onInit();
+		assert.ok(oAppController);
+	});
+
+});

--- a/examples/packages/ordersv4freestyle/webapp/test/unit/unitTests.qunit.html
+++ b/examples/packages/ordersv4freestyle/webapp/test/unit/unitTests.qunit.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>Unit tests for ordersv4freestyle</title>
+	<script
+		id="sap-ui-bootstrap"
+		src="../../resources/sap-ui-core.js"
+		data-sap-ui-resourceroots='{
+			"ordersv4freestyle": "../../",
+			"unit": "."
+		}'
+		data-sap-ui-async="true"
+		data-sap-ui-oninit="module:unit/unitTests.qunit">
+	</script>
+	<link rel="stylesheet" type="text/css" href="../../resources/sap/ui/thirdparty/qunit-2.css">
+	<script src="../../resources/sap/ui/thirdparty/qunit-2.js"></script>
+	<script src="../../resources/sap/ui/qunit/qunit-junit.js"></script>
+	<script src="../../resources/sap/ui/qunit/qunit-coverage.js"></script>
+	<script src="../../resources/sap/ui/thirdparty/sinon.js"></script>
+	<script src="../../resources/sap/ui/thirdparty/sinon-qunit.js"></script>
+</head>
+<body>
+	<div id="qunit"></div>
+	<div id="qunit-fixture"></div>
+</body>
+</html>

--- a/examples/packages/ordersv4freestyle/webapp/test/unit/unitTests.qunit.js
+++ b/examples/packages/ordersv4freestyle/webapp/test/unit/unitTests.qunit.js
@@ -1,0 +1,12 @@
+/* global QUnit */
+QUnit.config.autostart = false;
+
+sap.ui.getCore().attachInit(function () {
+	"use strict";
+
+	sap.ui.require([
+		"ordersv4freestyle/test/unit/AllTests"
+	], function () {
+		QUnit.start();
+	});
+});

--- a/examples/packages/ordersv4freestyle/webapp/view/App.view.xml
+++ b/examples/packages/ordersv4freestyle/webapp/view/App.view.xml
@@ -1,0 +1,7 @@
+<mvc:View controllerName="ordersv4freestyle.controller.App"
+    xmlns:html="http://www.w3.org/1999/xhtml"
+    xmlns:mvc="sap.ui.core.mvc" displayBlock="true"
+    xmlns="sap.m">
+    <App id="app">
+    </App>
+</mvc:View>

--- a/examples/packages/ordersv4freestyle/webapp/view/MainView.view.xml
+++ b/examples/packages/ordersv4freestyle/webapp/view/MainView.view.xml
@@ -11,20 +11,22 @@
                     propagateModel="true"
                     async="true"
                     settings="{
-                    componentContainerData:{uploadButtonPress:'uploadButtonPress',buttonText:'Excel Download',downloadButton:true},
-                    deepDownloadConfig:{deepLevel: 2,
-                      deepExport: true,
-                      addKeysToExport: true,
-                      showOptions: true,
-                      filename: 'Orders12',
-                      columns : {
-                        'OrderNo':{
-                            'order': 1
+                    componentContainerData:{uploadButtonPress:'uploadButtonPress',buttonText:'Excel Download',buttonId:'downloadButton',downloadButton:true},
+                    deepDownloadConfig:{
+                        deepLevel: 0,
+                        deepExport: false,
+                        addKeysToExport: true,
+                        showOptions: false,
+                        filename: 'Orders12',
+                        columns : {
+                            'OrderNo':{
+                                'order': 1
                         }
                       }
                     }
                   }"
                 />
+                <Button id="downloadButtonCode" text="Excel Download Code" press="onDownload"/>
                 <!-- Added Table with OData binding -->
                 <Table id="ordersTable" items="{/Orders}">
                     <columns>

--- a/examples/packages/ordersv4freestyle/webapp/view/MainView.view.xml
+++ b/examples/packages/ordersv4freestyle/webapp/view/MainView.view.xml
@@ -1,7 +1,54 @@
 <mvc:View controllerName="ordersv4freestyle.controller.MainView"
-    xmlns:mvc="sap.ui.core.mvc" displayBlock="true"
+    xmlns:mvc="sap.ui.core.mvc" xmlns:core="sap.ui.core" displayBlock="true"
     xmlns="sap.m">
     <Page id="page" title="{i18n>title}">
-        <content />
+        <content>
+            <VBox>
+                <core:ComponentContainer
+                    id="test"
+                    width="100%"
+                    usage="spreadsheetImporter"
+                    propagateModel="true"
+                    async="true"
+                    settings="{
+                    componentContainerData:{uploadButtonPress:'uploadButtonPress',buttonText:'Excel Download',downloadButton:true},
+                    deepDownloadConfig:{deepLevel: 2,
+                      deepExport: true,
+                      addKeysToExport: true,
+                      showOptions: true,
+                      filename: 'Orders12',
+                      columns : {
+                        'OrderNo':{
+                            'order': 1
+                        }
+                      }
+                    }
+                  }"
+                />
+                <!-- Added Table with OData binding -->
+                <Table id="ordersTable" items="{/Orders}">
+                    <columns>
+                        <Column>
+                            <Text text="Order Number"/>
+                        </Column>
+                        <Column>
+                            <Text text="Buyer"/>
+                        </Column>
+                        <Column>
+                            <Text text="Created At"/>
+                        </Column>
+                    </columns>
+                    <items>
+                        <ColumnListItem>
+                            <cells>
+                                <Text text="{OrderNo}"/>
+                                <Text text="{buyer}"/>
+                                <Text text="{createdAt}"/>
+                            </cells>
+                        </ColumnListItem>
+                    </items>
+                </Table>
+            </VBox>
+        </content>
     </Page>
 </mvc:View>

--- a/examples/packages/ordersv4freestyle/webapp/view/MainView.view.xml
+++ b/examples/packages/ordersv4freestyle/webapp/view/MainView.view.xml
@@ -1,0 +1,7 @@
+<mvc:View controllerName="ordersv4freestyle.controller.MainView"
+    xmlns:mvc="sap.ui.core.mvc" displayBlock="true"
+    xmlns="sap.m">
+    <Page id="page" title="{i18n>title}">
+        <content />
+    </Page>
+</mvc:View>

--- a/examples/packages/server/db/data/sap.capire.orders-ShippingDetails.csv
+++ b/examples/packages/server/db/data/sap.capire.orders-ShippingDetails.csv
@@ -1,0 +1,4 @@
+ID;order_ID;address;city;state;postalCode;country;shipmentDate;arrivalDate;shipmentStatus
+58040e66-1dcd-4ffb-ab10-fdce32028b80;7e2f2640-6866-4dcf-8f4d-3027aa831cad;test street;test city;test state;12345;test country;2022-01-01T12:00:00Z;2022-01-01T12:00:00Z;test status
+64e718c9-ff99-47f1-8ca3-950c850777d5;7e2f2640-6866-4dcf-8f4d-3027aa831cad;test street;test city;test state;12345;test country;2022-01-01T12:00:00Z;2022-01-01T12:00:00Z;test status
+e9641166-e050-4261-bfee-d1e797e6cb8f;64e718c9-ff99-47f1-8ca3-950c850777d4;test street;test city;test state;12345;test country;2022-01-01T12:00:00Z;2022-01-01T12:00:00Z;test status

--- a/examples/test/specs/all/SetAvailableOptionsListReport.test.js
+++ b/examples/test/specs/all/SetAvailableOptionsListReport.test.js
@@ -82,7 +82,7 @@ describe("Upload File List Report", () => {
 		if (settingsButton._domId === undefined) {
 			const toolbarContent = await overflowToolbar.getContent();
 			// 4 is the index of the settings button
-			settingsButton = toolbarContent[4];
+			settingsButton = toolbarContent[5];
 		}
 		await settingsButton.press();
 	});

--- a/examples/test/specs/download/DownloadSpreadsheetListReport.test.js
+++ b/examples/test/specs/download/DownloadSpreadsheetListReport.test.js
@@ -1,0 +1,109 @@
+const FEV2ND = require("../Objects/FEV2ND");
+const Base = require("./../Objects/Base");
+const FEV2 = require("./../Objects/FEV2");
+const FEV4 = require("./../Objects/FEV4");
+const { optionsLong, optionsShort } = require("./../Objects/types");
+const path = require('path');
+const fs = require('fs');
+const XLSX = require('xlsx');
+
+let FE = undefined;
+let BaseClass = undefined;
+let scenario = undefined;
+
+describe("Download Spreadsheet List Report", () => {
+    before(async () => {
+        BaseClass = new Base();
+        scenario = global.scenario;
+        if (scenario.startsWith("ordersv2")) {
+            FE = new FEV2();
+        }
+        if (scenario.startsWith("ordersv4")) {
+            FE = new FEV4();
+        }
+        if (scenario.startsWith("ordersv2fenondraft")) {
+            FE = new FEV2ND();
+        }
+    });
+
+    it("should trigger search on ListReport page", async () => {
+        try {
+            await BaseClass.pressById(FE.listReportGoButton);
+        } catch (error) {
+            await BaseClass.pressById(FE.listReportDynamicPageTitle);
+            await BaseClass.dummyWait(500);
+            await BaseClass.pressById(FE.listReportGoButton);
+        }
+    });
+
+    it("Open Spreadsheet Upload Dialog", async () => {
+        await BaseClass.pressById(FE.listReportSpreadsheetuploadButton);
+        const spreadsheetUploadDialog = await browser.asControl({
+            selector: {
+                controlType: "sap.m.Dialog",
+                properties: {
+                    contentWidth: "40vw"
+                },
+                searchOpenDialogs: true
+            }
+        });
+        expect(spreadsheetUploadDialog.isOpen()).toBeTruthy();
+    });
+
+    it("Download spreadsheet and verify content", async () => {
+        // Click download button
+        await browser.asControl({
+            selector: {
+                controlType: "sap.m.Button",
+                properties: {
+                    text: "Download Spreadsheet"
+                },
+                searchOpenDialogs: true
+            }
+        }).press();
+
+        // Wait for download to complete
+        await browser.pause(2000);
+
+        // Get the downloaded file
+        const downloadDir = browser.config.downloadDir;
+        const files = fs.readdirSync(downloadDir);
+        const downloadedFile = files.find(file => file.endsWith('.xlsx'));
+        expect(downloadedFile).toBeDefined();
+
+        // Read the Excel file
+        const filePath = path.join(downloadDir, downloadedFile);
+        const workbook = XLSX.readFile(filePath);
+
+        // Verify workbook structure
+        expect(workbook.SheetNames.length).toBeGreaterThan(0);
+
+        // Read the first sheet
+        const firstSheet = workbook.Sheets[workbook.SheetNames[0]];
+        const data = XLSX.utils.sheet_to_json(firstSheet);
+
+        // Verify data
+        expect(data.length).toBeGreaterThan(0);
+        
+        // Example verification - adjust according to your expected data structure
+        if (data[0]) {
+            expect(data[0]).toHaveProperty('OrderNo');
+            // Add more specific checks based on your data structure
+        }
+
+        // Clean up - delete the downloaded file
+        fs.unlinkSync(filePath);
+    });
+
+    it("Close SpreadsheetUpload Dialog", async () => {
+        await browser.asControl({
+            selector: {
+                controlType: "sap.m.Button",
+                properties: {
+                    text: "Close"
+                },
+                searchOpenDialogs: true
+            }
+        }).press();
+    });
+}); 

--- a/examples/test/wdio-base.conf.js
+++ b/examples/test/wdio-base.conf.js
@@ -1,4 +1,6 @@
 const { escape } = require("querystring");
+const path = require('path');
+const downloadDir = path.resolve(__dirname, 'downloads');
 const util = require("./../../dev/util");
 const { TimelineService } = require('wdio-timeline-reporter/timeline-service');
 let scenario = "";
@@ -40,7 +42,12 @@ module.exports.config = {
 						? ["--headless=new", "--window-size=1920,1080"]
 						: process.argv.indexOf("--debug") > -1
 						? ["--window-size=1920,1080", "--auto-open-devtools-for-tabs"]
-						: ["--window-size=1920,1080"]
+						: ["--window-size=1920,1080"],
+            prefs: {
+                'download.default_directory': downloadDir,
+                'download.prompt_for_download': false,
+                'download.directory_upgrade': true
+            }
 			},
 			acceptInsecureCerts: true
 		}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ nav:
   - Events: pages/Events.md
   - Error Handling: pages/Checks.md
   - Table Selector: pages/TableSelector.md
+  - Spreadsheet Download: pages/Spreadsheetdownload.md
   - Typescript: pages/Typescript.md
   - Supported Versions: pages/SupportVersions.md
   - Central Deployment: pages/CentralDeployment.md
@@ -21,7 +22,6 @@ nav:
   # - UI5 CLI: pages/CLI.md
   - Pro:
       - Getting Started: pages/Pro/install.md
-      - Spreadsheet Download: pages/Pro/spreadsheetdownload.md
       - Deep Create: pages/Pro/deepcreate.md
   - Development:
       - Getting Started: pages/Development/GettingStarted.md
@@ -30,6 +30,7 @@ nav:
       - Docs: pages/Development/Docs.md
       - GitHub Actions: pages/Development/GitHubActions.md
       - Sample Apps: pages/Development/SampleApps.md
+      - Spreadsheet Download: pages/Development/SpreadsheetDownload.md
   - Changelogs:
       - spreadsheetimporter: pages/CHANGELOGSPREADSHEETIMPORTER.md
   - Troubleshooting: pages/Troubleshooting.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,7 +13,7 @@ nav:
   - Events: pages/Events.md
   - Error Handling: pages/Checks.md
   - Table Selector: pages/TableSelector.md
-  - Spreadsheet Download: pages/Spreadsheetdownload.md
+  - Deep Download: pages/Spreadsheetdownload.md
   - Typescript: pages/Typescript.md
   - Supported Versions: pages/SupportVersions.md
   - Central Deployment: pages/CentralDeployment.md

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "start:v2fe:120": "pnpm --filter ordersv2fe120 start",
     "start:v4fe:120": "pnpm --filter ordersv4fe120 start",
     "start:anyupload": "pnpm --filter anyupload start",
+    "start:v4freestyle": "pnpm --filter ordersv4freestyle start",
     "test:v4fe:120": "pnpm --filter ui5-cc-spreadsheetimporter-sample test -- -- ordersv4fe 120",
     "test:opa5:v4fe:120": "pnpm --filter ui5-cc-spreadsheetimporter-sample ui5-test-runner --url http://localhost:8080/test/integration/opaTests.qunit.html",
     "test:v2fe:120": "pnpm --filter ui5-cc-spreadsheetimporter-sample test -- -- ordersv2fe 120",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start:v2fe:120": "pnpm --filter ordersv2fe120 start",
     "start:v4fe:120": "pnpm --filter ordersv4fe120 start",
     "start:anyupload": "pnpm --filter anyupload start",
-    "start:v4freestyle": "pnpm --filter ordersv4freestyle start",
+    "start:v4freestyle": "pnpm --filter ordersv4freestyle120 start",
     "test:v4fe:120": "pnpm --filter ui5-cc-spreadsheetimporter-sample test -- -- ordersv4fe 120",
     "test:opa5:v4fe:120": "pnpm --filter ui5-cc-spreadsheetimporter-sample ui5-test-runner --url http://localhost:8080/test/integration/opaTests.qunit.html",
     "test:v2fe:120": "pnpm --filter ui5-cc-spreadsheetimporter-sample test -- -- ordersv2fe 120",

--- a/packages/ui5-cc-spreadsheetimporter/src/Component.gen.d.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/Component.gen.d.ts
@@ -42,6 +42,7 @@ declare module "./Component" {
         debug?: boolean | PropertyBindingInfo | `{${string}}`;
         componentContainerData?: object | PropertyBindingInfo | `{${string}}`;
         bindingCustom?: object | PropertyBindingInfo | `{${string}}`;
+        showDownloadButton?: boolean | PropertyBindingInfo | `{${string}}`;
         deepDownloadConfig?: object | PropertyBindingInfo | `{${string}}`;
         preFileProcessing?: (event: Component$PreFileProcessingEvent) => void;
         checkBeforeRead?: (event: Component$CheckBeforeReadEvent) => void;
@@ -187,6 +188,10 @@ declare module "./Component" {
         // property: bindingCustom
         getBindingCustom(): object;
         setBindingCustom(bindingCustom: object): this;
+
+        // property: showDownloadButton
+        getShowDownloadButton(): boolean;
+        setShowDownloadButton(showDownloadButton: boolean): this;
 
         // property: deepDownloadConfig
         getDeepDownloadConfig(): object;

--- a/packages/ui5-cc-spreadsheetimporter/src/Component.gen.d.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/Component.gen.d.ts
@@ -49,6 +49,8 @@ declare module "./Component" {
         changeBeforeCreate?: (event: Component$ChangeBeforeCreateEvent) => void;
         requestCompleted?: (event: Component$RequestCompletedEvent) => void;
         uploadButtonPress?: (event: Component$UploadButtonPressEvent) => void;
+        beforeDownloadFileProcessing?: (event: Component$BeforeDownloadFileProcessingEvent) => void;
+        beforeDownloadFileExport?: (event: Component$BeforeDownloadFileExportEvent) => void;
     }
 
     export default interface Component {
@@ -226,6 +228,18 @@ declare module "./Component" {
         attachUploadButtonPress<CustomDataType extends object>(data: CustomDataType, fn: (event: Component$UploadButtonPressEvent, data: CustomDataType) => void, listener?: object): this;
         detachUploadButtonPress(fn: (event: Component$UploadButtonPressEvent) => void, listener?: object): this;
         fireUploadButtonPress(parameters?: Component$UploadButtonPressEventParameters): boolean;
+
+        // event: beforeDownloadFileProcessing
+        attachBeforeDownloadFileProcessing(fn: (event: Component$BeforeDownloadFileProcessingEvent) => void, listener?: object): this;
+        attachBeforeDownloadFileProcessing<CustomDataType extends object>(data: CustomDataType, fn: (event: Component$BeforeDownloadFileProcessingEvent, data: CustomDataType) => void, listener?: object): this;
+        detachBeforeDownloadFileProcessing(fn: (event: Component$BeforeDownloadFileProcessingEvent) => void, listener?: object): this;
+        fireBeforeDownloadFileProcessing(parameters?: Component$BeforeDownloadFileProcessingEventParameters): this;
+
+        // event: beforeDownloadFileExport
+        attachBeforeDownloadFileExport(fn: (event: Component$BeforeDownloadFileExportEvent) => void, listener?: object): this;
+        attachBeforeDownloadFileExport<CustomDataType extends object>(data: CustomDataType, fn: (event: Component$BeforeDownloadFileExportEvent, data: CustomDataType) => void, listener?: object): this;
+        detachBeforeDownloadFileExport(fn: (event: Component$BeforeDownloadFileExportEvent) => void, listener?: object): this;
+        fireBeforeDownloadFileExport(parameters?: Component$BeforeDownloadFileExportEventParameters): this;
     }
 
     /**
@@ -268,6 +282,21 @@ declare module "./Component" {
     }
 
     /**
+     * Interface describing the parameters of Component's 'beforeDownloadFileProcessing' event.
+     */
+    export interface Component$BeforeDownloadFileProcessingEventParameters {
+        data?: object;
+    }
+
+    /**
+     * Interface describing the parameters of Component's 'beforeDownloadFileExport' event.
+     */
+    export interface Component$BeforeDownloadFileExportEventParameters {
+        workbook?: object;
+        filename?: string;
+    }
+
+    /**
      * Type describing the Component's 'preFileProcessing' event.
      */
     export type Component$PreFileProcessingEvent = Event<Component$PreFileProcessingEventParameters>;
@@ -291,4 +320,14 @@ declare module "./Component" {
      * Type describing the Component's 'uploadButtonPress' event.
      */
     export type Component$UploadButtonPressEvent = Event<Component$UploadButtonPressEventParameters>;
+
+    /**
+     * Type describing the Component's 'beforeDownloadFileProcessing' event.
+     */
+    export type Component$BeforeDownloadFileProcessingEvent = Event<Component$BeforeDownloadFileProcessingEventParameters>;
+
+    /**
+     * Type describing the Component's 'beforeDownloadFileExport' event.
+     */
+    export type Component$BeforeDownloadFileExportEvent = Event<Component$BeforeDownloadFileExportEventParameters>;
 }

--- a/packages/ui5-cc-spreadsheetimporter/src/Component.gen.d.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/Component.gen.d.ts
@@ -42,6 +42,7 @@ declare module "./Component" {
         debug?: boolean | PropertyBindingInfo | `{${string}}`;
         componentContainerData?: object | PropertyBindingInfo | `{${string}}`;
         bindingCustom?: object | PropertyBindingInfo | `{${string}}`;
+        deepDownloadConfig?: object | PropertyBindingInfo | `{${string}}`;
         preFileProcessing?: (event: Component$PreFileProcessingEvent) => void;
         checkBeforeRead?: (event: Component$CheckBeforeReadEvent) => void;
         changeBeforeCreate?: (event: Component$ChangeBeforeCreateEvent) => void;
@@ -186,6 +187,10 @@ declare module "./Component" {
         // property: bindingCustom
         getBindingCustom(): object;
         setBindingCustom(bindingCustom: object): this;
+
+        // property: deepDownloadConfig
+        getDeepDownloadConfig(): object;
+        setDeepDownloadConfig(deepDownloadConfig: object): this;
 
         // event: preFileProcessing
         attachPreFileProcessing(fn: (event: Component$PreFileProcessingEvent) => void, listener?: object): this;

--- a/packages/ui5-cc-spreadsheetimporter/src/Component.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/Component.ts
@@ -112,6 +112,17 @@ export default class Component extends UIComponent {
 					rawData: { type: "object" },
 					parsedData: { type: "object" }
 				}
+			},
+			beforeDownloadFileProcessing: {
+				parameters: {
+					data: { type: "object" }
+				}
+			},
+			beforeDownloadFileExport: {
+				parameters: {
+					workbook: { type: "object" },
+					filename: { type: "string" }
+				}
 			}
 		}
 	};
@@ -275,7 +286,9 @@ export default class Component extends UIComponent {
 			uploadButtonPress: this.attachUploadButtonPress,
 			changeBeforeCreate: this.attachChangeBeforeCreate,
 			checkBeforeRead: this.attachCheckBeforeRead,
-			requestCompleted: this.attachRequestCompleted
+			requestCompleted: this.attachRequestCompleted,
+			beforeDownloadFileProcessing: this.attachBeforeDownloadFileProcessing,
+			beforeDownloadFileExport: this.attachBeforeDownloadFileExport
 		};
 		if (componentContainerOptions) {
 			for (const [eventName, attachMethod] of Object.entries(eventMethodMap)) {

--- a/packages/ui5-cc-spreadsheetimporter/src/Component.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/Component.ts
@@ -71,6 +71,7 @@ export default class Component extends UIComponent {
 			debug: { type: "boolean", defaultValue: false },
 			componentContainerData: { type: "object" },
 			bindingCustom: { type: "object" },
+			showDownloadButton: { type: "boolean", defaultValue: false },
 			deepDownloadConfig: { type: "object", defaultValue: {} }
 			//Pro Configurations
 		},
@@ -159,6 +160,7 @@ export default class Component extends UIComponent {
 		this.setCreateActiveEntity(compData?.createActiveEntity);
 		this.setI18nModel(compData?.i18nModel);
 		this.setBindingCustom(compData?.bindingCustom);
+		this.setShowDownloadButton(compData?.showDownloadButton);
 		if (compData?.availableOptions && compData?.availableOptions.length > 0) {
 			// if availableOptions is set show the Options Menu
 			this.setShowOptions(true);

--- a/packages/ui5-cc-spreadsheetimporter/src/Component.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/Component.ts
@@ -206,7 +206,7 @@ export default class Component extends UIComponent {
 		this.spreadsheetUpload = new SpreadsheetUpload(this, this.getModel("i18n") as ResourceModel);
 		const componentContainerData = this.getComponentContainerData?.() || {};
 		const buttonText = componentContainerData.buttonText ?? "Excel Import";
-		const buttonId = this.createId(componentContainerData.buttonId)
+		const buttonId = componentContainerData.buttonId
 		
 		// Check if the download button should be enabled
 		const showDownloadButton = componentContainerData.downloadButton ?? false;
@@ -217,7 +217,7 @@ export default class Component extends UIComponent {
 		}
 
 		if(buttonId) {
-			return new Button({ id: buttonId, text: buttonText, press: pressMethod });
+			return new Button({ id: this.createId(buttonId), text: buttonText, press: pressMethod });
 		}
 
 		return new Button({ text: buttonText, press: pressMethod });

--- a/packages/ui5-cc-spreadsheetimporter/src/Component.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/Component.ts
@@ -206,6 +206,7 @@ export default class Component extends UIComponent {
 		this.spreadsheetUpload = new SpreadsheetUpload(this, this.getModel("i18n") as ResourceModel);
 		const componentContainerData = this.getComponentContainerData?.() || {};
 		const buttonText = componentContainerData.buttonText ?? "Excel Import";
+		const buttonId = this.createId(componentContainerData.buttonId)
 		
 		// Check if the download button should be enabled
 		const showDownloadButton = componentContainerData.downloadButton ?? false;
@@ -213,6 +214,10 @@ export default class Component extends UIComponent {
 
 		if(showDownloadButton) {
 			pressMethod = () => this.triggerDownloadSpreadsheet();
+		}
+
+		if(buttonId) {
+			return new Button({ id: buttonId, text: buttonText, press: pressMethod });
 		}
 
 		return new Button({ text: buttonText, press: pressMethod });

--- a/packages/ui5-cc-spreadsheetimporter/src/Component.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/Component.ts
@@ -206,7 +206,16 @@ export default class Component extends UIComponent {
 		this.spreadsheetUpload = new SpreadsheetUpload(this, this.getModel("i18n") as ResourceModel);
 		const componentContainerData = this.getComponentContainerData?.() || {};
 		const buttonText = componentContainerData.buttonText ?? "Excel Import";
-		return new Button({ text: buttonText, press: () => this.openSpreadsheetUploadDialog() });
+		
+		// Check if the download button should be enabled
+		const showDownloadButton = componentContainerData.downloadButton ?? false;
+		let pressMethod = () => this.openSpreadsheetUploadDialog();
+
+		if(showDownloadButton) {
+			pressMethod = () => this.triggerDownloadSpreadsheet();
+		}
+
+		return new Button({ text: buttonText, press: pressMethod });
 	}
 
 	//=============================================================================
@@ -231,6 +240,22 @@ export default class Component extends UIComponent {
 		}
 		Log.debug("openSpreadsheetUploadDialog", undefined, "SpreadsheetUpload: Component");
 		this.spreadsheetUpload.openSpreadsheetUploadDialog(options);
+	}
+
+	async triggerDownloadSpreadsheet(deepDownloadConfig?: DeepDownloadConfig) {
+		if (!this.getContext()) {
+			// if loaded via ComponentContainer, context is not set
+			const context = this._getViewControllerOfControl(this.oContainer);
+			this.setContext(context);
+			// attach event from ComponentContainer
+			this._attachEvents(context);
+		}
+		await this.spreadsheetUpload.initializeComponent();
+		Log.debug("triggerDownloadSpreadsheet", undefined, "SpreadsheetUpload: Component");
+		if (deepDownloadConfig) {
+			this.setDeepDownloadConfig(deepDownloadConfig);
+		}
+		this.spreadsheetUpload.triggerDownloadSpreadsheet();
 	}
 
 	/**
@@ -279,22 +304,6 @@ export default class Component extends UIComponent {
 
 	getMessages(): Messages[] {
 		return this.spreadsheetUpload.getMessages();
-	}
-
-	async triggerDownloadSpreadsheet(deepDownloadConfig?: DeepDownloadConfig) {
-		await this.spreadsheetUpload.initializeComponent();
-		if (!this.getContext()) {
-			// if loaded via ComponentContainer, context is not set
-			const context = this._getViewControllerOfControl(this.oContainer);
-			this.setContext(context);
-			// attach event from ComponentContainer
-			this._attachEvents(context);
-		}
-		Log.debug("triggerDownloadSpreadsheet", undefined, "SpreadsheetUpload: Component");
-		if (deepDownloadConfig) {
-			this.setDeepDownloadConfig(deepDownloadConfig);
-		}
-		this.spreadsheetUpload.triggerDownloadSpreadsheet();
 	}
 
 	//=============================================================================

--- a/packages/ui5-cc-spreadsheetimporter/src/Component.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/Component.ts
@@ -281,6 +281,22 @@ export default class Component extends UIComponent {
 		return this.spreadsheetUpload.getMessages();
 	}
 
+	async triggerDownloadSpreadsheet(deepDownloadConfig?: DeepDownloadConfig) {
+		await this.spreadsheetUpload.initializeComponent();
+		if (!this.getContext()) {
+			// if loaded via ComponentContainer, context is not set
+			const context = this._getViewControllerOfControl(this.oContainer);
+			this.setContext(context);
+			// attach event from ComponentContainer
+			this._attachEvents(context);
+		}
+		Log.debug("triggerDownloadSpreadsheet", undefined, "SpreadsheetUpload: Component");
+		if (deepDownloadConfig) {
+			this.setDeepDownloadConfig(deepDownloadConfig);
+		}
+		this.spreadsheetUpload.triggerDownloadSpreadsheet();
+	}
+
 	//=============================================================================
 	//EVENT HANDLERS
 	//=============================================================================

--- a/packages/ui5-cc-spreadsheetimporter/src/Component.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/Component.ts
@@ -2,7 +2,7 @@ import UIComponent from "sap/ui/core/UIComponent";
 import JSONModel from "sap/ui/model/json/JSONModel";
 import Device from "sap/ui/Device";
 import SpreadsheetUpload from "./controller/SpreadsheetUpload";
-import { ComponentData, Messages } from "./types";
+import { ComponentData, DeepDownloadConfig, Messages } from "./types";
 import Log from "sap/base/Log";
 import ResourceModel from "sap/ui/model/resource/ResourceModel";
 import Logger from "./controller/Logger";
@@ -10,6 +10,7 @@ import ComponentContainer from "sap/ui/core/ComponentContainer";
 import Button from "sap/m/Button";
 import Controller from "sap/ui/core/mvc/Controller";
 import View from "sap/ui/core/mvc/View";
+import Util from "./controller/Util";
 /**
  * @namespace cc.spreadsheetimporter.XXXnamespaceXXX
  */
@@ -69,7 +70,8 @@ export default class Component extends UIComponent {
 			i18nModel: { type: "object" },
 			debug: { type: "boolean", defaultValue: false },
 			componentContainerData: { type: "object" },
-			bindingCustom: { type: "object" }
+			bindingCustom: { type: "object" },
+			deepDownloadConfig: { type: "object", defaultValue: {} }
 			//Pro Configurations
 		},
 		aggregations: {
@@ -161,6 +163,17 @@ export default class Component extends UIComponent {
 			// if availableOptions is set show the Options Menu
 			this.setShowOptions(true);
 		}
+
+		const defaultDeepDownloadConfig: DeepDownloadConfig = {
+				addKeysToExport: false,
+				deepExport: false,
+				deepLevel: 1,
+				showOptions: true,
+				columns: []
+		};
+
+	    const mergedDeepDownloadConfig = Util.mergeConfig(defaultDeepDownloadConfig, compData.deepDownloadConfig)
+		this.setDeepDownloadConfig(mergedDeepDownloadConfig);
 
 		// Pro Configurations - Start
 

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/SpreadsheetUpload.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/SpreadsheetUpload.ts
@@ -23,7 +23,6 @@ export default class SpreadsheetUpload extends ManagedObject {
 	public component: Component;
 	public context: any;
 	private _isODataV4: boolean;
-	private isOpenUI5: boolean;
 	private _view: XMLView;
 	private _tableObject: any;
 	private messageHandler: MessageHandler;
@@ -142,6 +141,10 @@ export default class SpreadsheetUpload extends ManagedObject {
 		this.typeLabelList = await this.odataHandler.getLabelList(this.component.getColumns(), this._odataType, this.component.getExcludeColumns(), this.binding);
 		Log.debug("typeLabelList", undefined, "SpreadsheetUpload: SpreadsheetUpload", () => this.component.logger.returnObject({ typeLabelList: this.typeLabelList }));
 
+		const { mainEntity, expands } = this.odataHandler.getODataEntitiesRecursive(this.getOdataType(), Infinity);
+		Log.debug("mainEntity", undefined, "SpreadsheetUpload: SpreadsheetUpload", () => this.component.logger.returnObject({ mainEntity: mainEntity }));
+		Log.debug("expands", undefined, "SpreadsheetUpload: SpreadsheetUpload", () => this.component.logger.returnObject({ expands: expands }));
+
 		this.model = this.binding.getModel();
 		Log.debug("model", undefined, "SpreadsheetUpload: SpreadsheetUpload", () => this.component.logger.returnObject({ model: this.model }));
 		this.odataHandler.createCustomBinding(this.binding);
@@ -170,26 +173,37 @@ export default class SpreadsheetUpload extends ManagedObject {
 	}
 
 	/**
-	 * Opens the Spreadsheet upload dialog.
-	 * @param {object} options - all component options.
+	 * Initializes the component with options and performs initial setup
+	 * @param {ComponentData} options - Configuration options
+	 * @returns {Promise<void>}
 	 */
-	async openSpreadsheetUploadDialog(options: ComponentData) {
-		if (options) {
-			// set options to component
-			this.setComponentOptions(options);
-			this.initialSetupPromise = this.initialSetup();
-		} else {
-			this.initialSetupPromise = this.initialSetup();
-		}
+	async initializeComponent(): Promise<void> {
+		this.initialSetupPromise = this.initialSetup();
 		await this.initialSetupPromise;
-		if (!this.errorState) {
-			// ((this.spreadsheetUploadDialogHandler.getDialog().getContent()[0] as FlexBox).getItems()[1] as FileUploader).clear();
-			this.spreadsheetUploadDialogHandler.openSpreadsheetUploadDialog();
-		} else {
+		
+		if (this.errorState) {
 			Util.showError(this.errorMessage, "SpreadsheetUpload.ts", "initialSetup");
+			Log.error("Error during initialization", undefined, "SpreadsheetUpload: SpreadsheetUpload");
+			throw this.errorMessage;
+		}
+	}
+
+	/**
+	 * Opens the Spreadsheet upload dialog.
+	 * @param {ComponentData} options - Optional configuration options
+	 */
+	async openSpreadsheetUploadDialog(options?: ComponentData) {
+		try {
+			if (options) {
+				this.setComponentOptions(options);
+			}
+			await this.initializeComponent();
+			this.spreadsheetUploadDialogHandler.openSpreadsheetUploadDialog();
+		} catch (error) {
 			Log.error("Error opening the dialog", undefined, "SpreadsheetUpload: SpreadsheetUpload");
 		}
 	}
+
 	setComponentOptions(options: ComponentData) {
 		if (options.hasOwnProperty("spreadsheetFileName")) {
 			this.component.setSpreadsheetFileName(options.spreadsheetFileName);
@@ -377,6 +391,10 @@ export default class SpreadsheetUpload extends ManagedObject {
 		this.payload = [];
 		this.odataHandler.resetContexts();
 		this.spreadsheetUploadDialogHandler.resetContent();
+	}
+
+	triggerDownloadSpreadsheet() {
+		this.spreadsheetUploadDialogHandler.onDownloadDataSpreadsheet();
 	}
 
 	/**

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/SpreadsheetUpload.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/SpreadsheetUpload.ts
@@ -290,6 +290,9 @@ export default class SpreadsheetUpload extends ManagedObject {
 		if (options.hasOwnProperty("bindingCustom")) {
 			this.component.setBindingCustom(options.bindingCustom);
 		}
+		if (options.hasOwnProperty("showDownloadButton")) {
+			this.component.setShowDownloadButton(options.showDownloadButton);
+		}
 
 		// Special case for showOptions
 		if (options.availableOptions && options.availableOptions.length > 0) {

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/SpreadsheetUpload.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/SpreadsheetUpload.ts
@@ -131,6 +131,7 @@ export default class SpreadsheetUpload extends ManagedObject {
 		}
 		this.isODataV4 = this._checkIfODataIsV4(this.binding);
 		this.odataHandler = this.createODataHandler(this);
+		this.spreadsheetUploadDialogHandler.setODataHandler(this.odataHandler);
 		this.controller = this.view.getController();
 		Log.debug("View", undefined, "SpreadsheetUpload: SpreadsheetUpload", () => this.component.logger.returnObject({ view: this.view }));
 		this.view.addDependent(this.spreadsheetUploadDialogHandler.getDialog());
@@ -141,9 +142,11 @@ export default class SpreadsheetUpload extends ManagedObject {
 		this.typeLabelList = await this.odataHandler.getLabelList(this.component.getColumns(), this._odataType, this.component.getExcludeColumns(), this.binding);
 		Log.debug("typeLabelList", undefined, "SpreadsheetUpload: SpreadsheetUpload", () => this.component.logger.returnObject({ typeLabelList: this.typeLabelList }));
 
-		const { mainEntity, expands } = this.odataHandler.getODataEntitiesRecursive(this.getOdataType(), Infinity);
-		Log.debug("mainEntity", undefined, "SpreadsheetUpload: SpreadsheetUpload", () => this.component.logger.returnObject({ mainEntity: mainEntity }));
-		Log.debug("expands", undefined, "SpreadsheetUpload: SpreadsheetUpload", () => this.component.logger.returnObject({ expands: expands }));
+		if(this.isODataV4) {
+			const { mainEntity, expands } = this.odataHandler.getODataEntitiesRecursive(this.getOdataType(), Infinity);
+			Log.debug("mainEntity", undefined, "SpreadsheetUpload: SpreadsheetUpload", () => this.component.logger.returnObject({ mainEntity: mainEntity }));
+			Log.debug("expands", undefined, "SpreadsheetUpload: SpreadsheetUpload", () => this.component.logger.returnObject({ expands: expands }));
+		}
 
 		this.model = this.binding.getModel();
 		Log.debug("model", undefined, "SpreadsheetUpload: SpreadsheetUpload", () => this.component.logger.returnObject({ model: this.model }));

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/SpreadsheetUpload.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/SpreadsheetUpload.ts
@@ -397,7 +397,7 @@ export default class SpreadsheetUpload extends ManagedObject {
 	}
 
 	triggerDownloadSpreadsheet() {
-		this.spreadsheetUploadDialogHandler.onDownloadDataSpreadsheet();
+		this.spreadsheetUploadDialogHandler.onInitDownloadSpreadsheetProcess();
 	}
 
 	/**

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/Util.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/Util.ts
@@ -2,7 +2,7 @@ import ManagedObject from "sap/ui/base/ManagedObject";
 import Log from "sap/base/Log";
 import type ResourceBundle from "sap/base/i18n/ResourceBundle";
 import MessageBox from "sap/m/MessageBox";
-import type { FireEventReturnType, RowData, ValueData } from "../types";
+import type { DeepDownloadConfig, FireEventReturnType, RowData, ValueData } from "../types";
 import type Component from "../Component";
 import type { FieldMatchType } from "../enums";
 import ObjectPool from "sap/ui/base/ObjectPool";
@@ -244,5 +244,17 @@ export default class Util extends ManagedObject {
 			mParameters: (event as any)?.mParameters,
 			returnValue: promises[0]
 		};
+	}
+
+	static mergeConfig(defaultConfig: DeepDownloadConfig, providedConfig?: DeepDownloadConfig): DeepDownloadConfig {
+		if (!providedConfig) return defaultConfig;
+
+		// Deep merge for spreadsheetExportConfig
+		const mergedDeepDownloadConfig: DeepDownloadConfig = {
+			...defaultConfig,
+			...providedConfig
+		};
+
+		return mergedDeepDownloadConfig;
 	}
 }

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/Util.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/Util.ts
@@ -181,6 +181,18 @@ export default class Util extends ManagedObject {
 		URL.revokeObjectURL(url);
 	}
 
+	static async getLanguage(): Promise<string> {
+		try {
+			// getCore is not available in UI5 version 2.0 and above, prefer this over sap.ui.getCore().getConfiguration().getLanguage()
+			const Localization = await Util.loadUI5RessourceAsync("sap/base/i18n/Localization");
+			return Localization.getLanguage();
+		} catch (error) {
+			Log.debug("sap/base/i18n/Localization not found", undefined, "SpreadsheetUpload: checkForODataErrors");
+		}
+		// ui5lint-disable-next-line -- fallback for UI5 versions below 2.0
+		return sap.ui.getCore().getConfiguration().getLanguage();
+	}
+
 	static async loadUI5RessourceAsync(moduleName: string): Promise<any> {
 		const alreadyLoadedModule = sap.ui.require(moduleName);
 		if (alreadyLoadedModule) {

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/dialog/SpreadsheetUploadDialog.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/dialog/SpreadsheetUploadDialog.ts
@@ -755,7 +755,17 @@ export default class SpreadsheetUploadDialog extends ManagedObject {
 		if (!this.spreadsheetUploadController.errorState) {
 			try {
 				const mainEntitySiblings = await this.spreadsheetDownload.fetchData(this.component.getDeepDownloadConfig() as DeepDownloadConfig);
-				this.spreadsheetGenerator.downloadSpreadsheet(mainEntitySiblings, this.component.getDeepDownloadConfig() as DeepDownloadConfig);
+
+				let isDefaultPrevented = false;
+				try {
+					const asyncEventBeforeDownloadFileProcessing = await Util.fireEventAsync("beforeDownloadFileProcessing", { data: mainEntitySiblings }, this.component);
+					isDefaultPrevented = asyncEventBeforeDownloadFileProcessing.bPreventDefault;
+				} catch (error) {
+					Log.error("Error while calling the beforeDownloadFileProcessing event", error as Error, "SpreadsheetUploadDialog.ts");
+				}
+				if (!isDefaultPrevented) {
+					this.spreadsheetGenerator.downloadSpreadsheet(mainEntitySiblings, this.component.getDeepDownloadConfig() as DeepDownloadConfig);
+				}
 			} catch (error) {
 				console.error("Error in onDownloadDataSpreadsheet:", error);
 			}

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/dialog/SpreadsheetUploadDialog.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/dialog/SpreadsheetUploadDialog.ts
@@ -25,8 +25,8 @@ import Select from "sap/m/Select";
 import Item from "sap/ui/core/Item";
 import SpreadsheetDownloadDialog from "../download/SpreadsheetDownloadDialog";
 import SpreadsheetGenerator from "../download/SpreadsheetGenerator";
-import ODataV4 from "../odata/ODataV4";
 import SpreadsheetDownload from "../download/SpreadsheetDownload";
+import OData from "../odata/OData";
 
 type InputType = {
 	[key: string]: {
@@ -49,7 +49,6 @@ export default class SpreadsheetUploadDialog extends ManagedObject {
 	optionsHandler: OptionsDialog;
 	messageHandler: MessageHandler;
 	spreadsheetOptionsModel: JSONModel;
-	odataHandler: ODataV4;
 	spreadsheetGenerator: SpreadsheetGenerator;
 	spreadsheetDownload: SpreadsheetDownload;
 
@@ -62,9 +61,6 @@ export default class SpreadsheetUploadDialog extends ManagedObject {
 		this.previewHandler = new Preview(this.util);
 		this.optionsHandler = new OptionsDialog(spreadsheetUploadController);
 		this.messageHandler = messageHandler;
-		this.odataHandler = new ODataV4(this.spreadsheetUploadController);
-		this.spreadsheetGenerator = new SpreadsheetGenerator(this.spreadsheetUploadController, this.component, this.odataHandler);
-		this.spreadsheetDownload = new SpreadsheetDownload(this.spreadsheetUploadController, this.component, this.odataHandler);
 		this.spreadsheetDownloadDialog = new SpreadsheetDownloadDialog(this.spreadsheetUploadController, this);
 	}
 
@@ -743,6 +739,11 @@ export default class SpreadsheetUploadDialog extends ManagedObject {
 		}
 		// ui5lint-disable-next-line -- fallback for UI5 versions below 2.0
 		return sap.ui.getCore().getConfiguration().getLanguage();
+	}
+
+	setODataHandler(odataHandler: OData) {
+		this.spreadsheetGenerator = new SpreadsheetGenerator(this.spreadsheetUploadController, this.component, odataHandler);
+		this.spreadsheetDownload = new SpreadsheetDownload(this.spreadsheetUploadController, this.component, odataHandler);
 	}
 
 	/**

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/dialog/SpreadsheetUploadDialog.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/dialog/SpreadsheetUploadDialog.ts
@@ -492,7 +492,7 @@ export default class SpreadsheetUploadDialog extends ManagedObject {
 							colWidths.push({ wch: colWidthDefault });
 						} else if (value.type === "Edm.DateTimeOffset" || value.type === "Edm.DateTime") {
 							let format;
-							const currentLang = await this.getLanguage();
+							const currentLang = await Util.getLanguage();
 							if (currentLang.startsWith("en")) {
 								format = "mm/dd/yyyy hh:mm AM/PM";
 							} else {
@@ -727,18 +727,6 @@ export default class SpreadsheetUploadDialog extends ManagedObject {
 
 			dialog.open();
 		});
-	}
-
-	private async getLanguage(): Promise<string> {
-		try {
-			// getCore is not available in UI5 version 2.0 and above, prefer this over sap.ui.getCore().getConfiguration().getLanguage()
-			const Localization = await Util.loadUI5RessourceAsync("sap/base/i18n/Localization");
-			return Localization.getLanguage();
-		} catch (error) {
-			Log.debug("sap/base/i18n/Localization not found", undefined, "SpreadsheetUpload: checkForODataErrors");
-		}
-		// ui5lint-disable-next-line -- fallback for UI5 versions below 2.0
-		return sap.ui.getCore().getConfiguration().getLanguage();
 	}
 
 	setODataHandler(odataHandler: OData) {

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/download/DataAssigner.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/download/DataAssigner.ts
@@ -1,0 +1,87 @@
+import ManagedObject from "sap/ui/base/ManagedObject";
+
+/**
+ * @namespace cc.spreadsheetimporter.download.XXXnamespaceXXX
+ */
+export default class DataAssigner extends ManagedObject {
+    /**
+     * Recursively assigns data to entities and their sub-entities
+     * @param data - The data to be assigned
+     * @param entity - The entity to assign data to
+     */
+    assignData(data: any, entity: any): void {
+        // Iterate through properties of the current entity
+        for (const property in entity) {
+            // If the property signifies a fetchable entity
+            if (entity[property].$XYZFetchableEntity) {
+                let subEntityDataTotal = [];
+                for (const row in data) {
+                    const currentEntity = data[row];
+                    const subEntityData = currentEntity[property];
+                    if (subEntityData) {
+                        subEntityDataTotal = subEntityDataTotal.concat(subEntityData);
+                    }
+                    delete currentEntity[property]; // remove the data
+                }
+                entity[property].$XYZData = subEntityDataTotal;
+
+                // Recursive call to handle deeper levels
+                this.assignData(subEntityDataTotal, entity[property].$XYZEntity);
+            }
+        }
+    }
+
+    /**
+     * Assigns data to the root entity
+     * @param data - The data to be assigned
+     * @param entity - The root entity
+     */
+    assignDataRoot(data: any, entity: any): void {
+        // Iterate through properties of the current entity
+        entity.$XYZData = [];
+        let row = {};
+        for (const column in data) {
+            if (entity.hasOwnProperty(column) && !entity[column].$XYZFetchableEntity) {
+                if (!entity["$XYZColumns"]) entity["$XYZColumns"] = [];
+                row[column] = data[column];
+            }
+        }
+        entity.$XYZData.push(row);
+    }
+
+    /**
+     * Assigns columns to the root entity
+     * @param data - The data containing column information
+     * @param entity - The root entity
+     */
+    assignColumnsRoot(data: any, entity: any): void {
+        for (const column in data) {
+            if (entity.hasOwnProperty(column) && !entity[column].$XYZFetchableEntity) {
+                if (!entity["$XYZColumns"]) entity["$XYZColumns"] = [];
+                entity["$XYZColumns"].push(column);
+            }
+        }
+    }
+
+    /**
+     * Recursively assigns columns to sub-entities
+     * @param data - The data containing column information
+     * @param entity - The entity to assign columns to
+     */
+    assignColumns(data: any, entity: any): void {
+        for (const property in entity) {
+            // If the property signifies a fetchable entity
+            if (entity[property].$XYZFetchableEntity && data.hasOwnProperty(property)) {
+                const subEntity = entity[property].$XYZEntity;
+                // Defined Columns in the pro config
+                for (const column in data[property]) {
+                    if (subEntity.hasOwnProperty(column) && !subEntity[column].$XYZFetchableEntity) {
+                        if (!entity[property]["$XYZColumns"]) entity[property]["$XYZColumns"] = [];
+                        entity[property]["$XYZColumns"].push(column);
+                    }
+                }
+                this.assignColumns(data[property], entity[property].$XYZEntity);
+            }
+        }
+    }
+} 

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/download/SpreadsheetDownload.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/download/SpreadsheetDownload.ts
@@ -1,0 +1,329 @@
+import ManagedObject from "sap/ui/base/ManagedObject";
+import { EntityDefinition, EntityObject, PropertyWithOrder, DeepDownloadConfig } from "../../types";
+import * as XLSX from "xlsx";
+import SpreadsheetUpload from "../SpreadsheetUpload";
+import Component from "../../Component";
+import OData from "../odata/OData";
+import Util from "../Util";
+/**
+ * @namespace cc.spreadsheetimporter.download.XXXnamespaceXXX
+ */
+export default class SpreadsheetDownload extends ManagedObject {
+	spreadsheetUploadController: SpreadsheetUpload;
+	component: Component;
+	odataHandler: OData;
+
+	constructor(spreadsheetUploadController: SpreadsheetUpload, component: Component, odataHandler: OData) {
+		super();
+		this.spreadsheetUploadController = spreadsheetUploadController;
+		this.component = component;
+		this.odataHandler = odataHandler;
+	}
+
+	async downloadSpreadsheet(entityDefinition: EntityDefinition, spreadsheetExportConfig: DeepDownloadConfig): Promise<void> {
+		let filename = spreadsheetExportConfig.filename || this.spreadsheetUploadController.getOdataType() + ".xlsx";
+		const wb = XLSX.utils.book_new(); // creating the new spreadsheet work book
+
+		await this._appendRootEntitySheet(wb, entityDefinition, spreadsheetExportConfig);
+		if (spreadsheetExportConfig.deepExport) {
+			await this._appendSiblingsSheetsRecursively(wb, entityDefinition, entityDefinition, spreadsheetExportConfig);
+		}
+		// check if filename ends with .xlsx if not add it
+		if (!filename.endsWith(".xlsx")) {
+			filename = filename.concat(".xlsx");
+		}
+
+		// download the created spreadsheet file
+		XLSX.writeFile(wb, filename);
+		// MessageToast.show(this.util.geti18nText("downloadingTemplate"));
+	}
+
+	async downloadSpreadsheetFlatTemplate(entityDefinition: EntityDefinition, downloadTemplate: boolean, spreadsheetExportConfig: DeepDownloadConfig): Promise<void> {
+		const properties = await this._extractProperties(spreadsheetExportConfig.columns, entityDefinition, "root");
+		// Sort properties based on the order and then map to get the property names
+		const sortedProperties = properties.sort((a, b) => a.order - b.order).map((p) => p.name);
+		var worksheet = {} as XLSX.WorkSheet;
+		// loop over sorted properties and add them to the worksheet
+		for (let i = 0; i < sortedProperties.length; i++) {
+			worksheet[XLSX.utils.encode_cell({ c: i, r: 0 })] = { v: sortedProperties[i], t: "s" };
+		}
+		worksheet["!ref"] = XLSX.utils.encode_range({ s: { c: 0, r: 0 }, e: { c: sortedProperties.length - 1, r: 0 } });
+		const wb = XLSX.utils.book_new();
+		wb.SheetNames.push("Template");
+		wb.Sheets["Template"] = worksheet;
+		// download the created spreadsheet file
+		XLSX.writeFile(wb, "Template.xlsx");
+	}
+
+	async _appendRootEntitySheet(wb: XLSX.WorkBook, entityDefinition: EntityDefinition, spreadsheetExportConfig: DeepDownloadConfig): Promise<void> {
+		if (entityDefinition.$XYZData) {
+			const data = entityDefinition.$XYZData;
+			const labelList = await this.odataHandler.getLabelList([], this.spreadsheetUploadController.getOdataType(), this.component.getExcludeColumns());
+			if (spreadsheetExportConfig.addKeysToExport) {
+				this.odataHandler.addKeys(labelList, this.spreadsheetUploadController.getOdataType());
+			}
+			const sheet = this._getSheet(labelList, data, entityDefinition.SiblingEntity.$Type, spreadsheetExportConfig, entityDefinition["$XYZColumns"], undefined);
+			const sheetName = this.spreadsheetUploadController.getOdataType().split(".").pop();
+			if (wb.SheetNames.includes(sheetName)) {
+				sheetName.concat("_1");
+			}
+			XLSX.utils.book_append_sheet(wb, sheet, sheetName);
+		}
+	}
+
+	async _appendSiblingsSheetsRecursively(
+		wb: XLSX.WorkBook,
+		entityDefinition: EntityDefinition,
+		parentEntity: any,
+		spreadsheetExportConfig: DeepDownloadConfig
+	): Promise<void> {
+		for (const property in entityDefinition) {
+			const currentEntity = entityDefinition[property];
+
+			if (!currentEntity.$XYZFetchableEntity) continue;
+			if (!currentEntity.$XYZData) continue;
+
+			// if (currentEntity["$XYZColumns"] && currentEntity["$XYZColumns"].length > 0) {
+				const data = currentEntity.$XYZData;
+
+				const labelList = await this.odataHandler.getLabelList([], currentEntity.$Type, this.component.getExcludeColumns());
+				if (spreadsheetExportConfig.addKeysToExport) {
+					this.odataHandler.addKeys(labelList, currentEntity.$Type, parentEntity, currentEntity.$Partner);
+				}
+
+				const sheet = this._getSheet(labelList, data, currentEntity.$Type, spreadsheetExportConfig, currentEntity["$XYZColumns"], entityDefinition.SiblingEntity.$Type);
+				let sheetName = currentEntity.$Type.split(".").pop();
+				let suffix = 0;
+				let originalSheetName = sheetName;
+				let availableLength = 31 - ("_" + suffix).length;
+				sheetName = originalSheetName.substring(0, availableLength) + (suffix > 0 ? "_" + suffix : "");
+
+				while (wb.SheetNames.includes(sheetName)) {
+					suffix++;
+					availableLength = 31 - ("_" + suffix).length;
+					sheetName = originalSheetName.substring(0, availableLength) + "_" + suffix;
+				}
+
+				XLSX.utils.book_append_sheet(wb, sheet, sheetName);
+			// }
+
+			// Recursively append other nested navigation properties.
+			// Also, pass the current entity as parent for the next level.
+			await this._appendSiblingsSheetsRecursively(wb, currentEntity.$XYZEntity, entityDefinition, spreadsheetExportConfig);
+		}
+	}
+
+	_getSheet(labelList: any, dataArray: any, entityType: string, spreadsheetExportConfig: DeepDownloadConfig, columnsConfig: string[], parentEntityType?: string): XLSX.WorkSheet {
+		let rows = dataArray.length;
+		let fieldMatchType = this.component.getFieldMatchType();
+		var worksheet = {} as XLSX.WorkSheet;
+		let colWidths: { wch: number }[] = []; // array to store column widths
+		const colWidthDefault = 15;
+		const colWidthDate = 20;
+		let col = 0;
+		let startRow = 0;
+		// remove columns from map labelist that are not in the config
+		if (columnsConfig && columnsConfig.length > 0) {
+			for (let key of labelList.keys()) {
+				if (!columnsConfig.includes(key)) {
+					labelList.delete(key);
+				}
+			}
+		}
+		// add column headers and data
+		for (let [key, value] of labelList.entries()) {
+			let width = colWidthDefault;
+			let cell = { v: "", t: "s" } as XLSX.CellObject;
+			let label = "";
+			if (fieldMatchType === "label") {
+				label = value.label;
+			}
+			if (fieldMatchType === "labelTypeBrackets") {
+				label = `${value.label}[${key}]`;
+			}
+			worksheet[XLSX.utils.encode_cell({ c: col, r: startRow })] = { v: label, t: "s" };
+
+			for (const [index, data] of dataArray.entries()) {
+				let sampleDataValue = "";
+				rows = index + 1 + startRow;
+				if (data[key]) {
+					sampleDataValue = data[key];
+				} else {
+					worksheet[XLSX.utils.encode_cell({ c: col, r: rows })] = { v: "", t: "s" }; // Set the cell as empty
+					continue; // Move to the next iteration
+				}
+				if (value.type === "Edm.Boolean") {
+					cell = {
+						v: sampleDataValue.toString(),
+						t: "b"
+					};
+				} else if (value.type === "Edm.String" || value.type === "Edm.Guid" || value.type === "Edm.Any") {
+					cell = { v: sampleDataValue, t: "s" };
+				} else if (value.type === "Edm.DateTimeOffset" || value.type === "Edm.DateTime") {
+					let format;
+					const currentLang = sap.ui.getCore().getConfiguration().getLanguage();
+					if (currentLang.startsWith("en")) {
+						format = "mm/dd/yyyy hh:mm AM/PM";
+					} else {
+						format = "dd.mm.yyyy hh:mm";
+					}
+
+					cell = { v: sampleDataValue, t: "d", z: format };
+					width = colWidthDate;
+				} else if (value.type === "Edm.Date") {
+					cell = {
+						v: sampleDataValue,
+						t: "d"
+					};
+				} else if (value.type === "Edm.TimeOfDay" || value.type === "Edm.Time") {
+					cell = {
+						v: sampleDataValue,
+						t: "d",
+						z: "hh:mm"
+					};
+				} else if (
+					value.type === "Edm.UInt8" ||
+					value.type === "Edm.Int16" ||
+					value.type === "Edm.Int32" ||
+					value.type === "Edm.Integer" ||
+					value.type === "Edm.Int64" ||
+					value.type === "Edm.Integer64"
+				) {
+					cell = {
+						v: sampleDataValue,
+						t: "n"
+					};
+				} else if (value.type === "Edm.Double" || value.type === "Edm.Decimal") {
+					const decimalSeparator = this.component.getDecimalSeparator();
+					cell = {
+						v: sampleDataValue,
+						t: "n"
+					};
+				}
+
+				worksheet[XLSX.utils.encode_cell({ c: col, r: rows })] = cell;
+			}
+			colWidths.push({ wch: width });
+			col++;
+		}
+
+		worksheet["!ref"] = XLSX.utils.encode_range({ s: { c: 0, r: 0 }, e: { c: col - 1, r: dataArray.length + startRow } });
+		worksheet["!cols"] = colWidths; // assign the column widths to the worksheet
+		return worksheet;
+	}
+
+	getFlatSheet() {}
+
+	// Function to extract the properties from input config and metadata
+	async _extractProperties(proConfigColumns: any, entityMetadata: any, entityType: string): Promise<PropertyWithOrder[]> {
+		const labelList = await this.odataHandler.getLabelList([], entityType, this.component.getExcludeColumns());
+		let properties: PropertyWithOrder[] = [];
+
+		for (let prop in proConfigColumns) {
+			if (proConfigColumns[prop].order !== undefined && proConfigColumns[prop].data !== undefined && entityMetadata[prop]) {
+				const label = labelList.get(prop);
+				let headerName: string;
+				if (label) {
+					headerName = `${label.label} [${entityType.split(".").pop()}][${prop}]`;
+				} else {
+					headerName = `${prop} [${entityType.split(".").pop()}][${prop}]`;
+				}
+				properties.push({ name: headerName, order: proConfigColumns[prop].order });
+			} else if (typeof proConfigColumns[prop] === "object") {
+				properties = properties.concat(await this._extractProperties(proConfigColumns[prop], entityMetadata[prop].$XYZEntity, entityMetadata[prop].$Type));
+			}
+		}
+
+		return properties;
+	}
+
+	_findAttributeByType(obj: Record<string, EntityObject>, typeToSearch: string): string | undefined {
+		for (const key in obj) {
+			if (obj.hasOwnProperty(key)) {
+				const entity = obj[key];
+				if (entity.$Type === typeToSearch) {
+					return key;
+				}
+			}
+		}
+		return undefined; // if not found
+	}
+
+	public async _fetchData(deepDownloadConfig: DeepDownloadConfig) {
+		const { mainEntity, expands } = this.odataHandler.getODataEntitiesRecursive(this.spreadsheetUploadController.getOdataType(), deepDownloadConfig.deepLevel);
+		const batchSize = 1000;
+		const customBinding = this.odataHandler.getBindingFromBinding(this.spreadsheetUploadController.binding, expands);
+
+		// Start fetching the batches
+		const totalResults = await this.odataHandler.fetchBatch(customBinding, batchSize);
+		const data = Util.extractObjects(totalResults);
+		this._recursiveAssignData(data, mainEntity);
+		this._recursiveAssignDataRoot(deepDownloadConfig.columns, mainEntity);
+		this._recursiveAssignColumnsRoot(deepDownloadConfig.columns, mainEntity);
+		this._recursiveAssignColumns(deepDownloadConfig.columns, mainEntity);
+		mainEntity.$XYZData = data;
+		return mainEntity;
+	}
+
+	private _recursiveAssignData(data: any, entity: any) {
+		// Iterate through properties of the current entity
+		for (const property in entity) {
+			// If the property signifies a fetchable entity
+			if (entity[property].$XYZFetchableEntity) {
+				let subEntityDataTotal = [];
+				for (const row in data) {
+					const currentEntity = data[row];
+					const subEntityData = currentEntity[property];
+					if (subEntityData) {
+						subEntityDataTotal = subEntityDataTotal.concat(subEntityData);
+					}
+					delete currentEntity[property]; // remove the data
+				}
+				entity[property].$XYZData = subEntityDataTotal;
+
+				// Recursive call to handle deeper levels
+				this._recursiveAssignData(subEntityDataTotal, entity[property].$XYZEntity);
+			}
+		}
+	}
+
+	private _recursiveAssignDataRoot(data: any, entity: any) {
+		// Iterate through properties of the current entity
+		entity.$XYZData = [];
+		let row = {};
+		for (const column in data) {
+			if (entity.hasOwnProperty(column) && !entity[column].$XYZFetchableEntity) {
+				if (!entity["$XYZColumns"]) entity["$XYZColumns"] = [];
+				row[column] = data[column];
+			}
+		}
+		entity.$XYZData.push(row);
+	}
+
+	private _recursiveAssignColumnsRoot(data: any, entity: any) {
+		for (const column in data) {
+			if (entity.hasOwnProperty(column) && !entity[column].$XYZFetchableEntity) {
+				if (!entity["$XYZColumns"]) entity["$XYZColumns"] = [];
+				entity["$XYZColumns"].push(column);
+			}
+		}
+	}
+
+	// function to assign columns to the sub entities
+	private _recursiveAssignColumns(data: any, entity: any) {
+		for (const property in entity) {
+			// If the property signifies a fetchable entity
+			if (entity[property].$XYZFetchableEntity && data.hasOwnProperty(property)) {
+				const subEntity = entity[property].$XYZEntity;
+				// Defined Columns in the pro config
+				for (const column in data[property]) {
+					if (subEntity.hasOwnProperty(column) && !subEntity[column].$XYZFetchableEntity) {
+						if (!entity[property]["$XYZColumns"]) entity[property]["$XYZColumns"] = [];
+						entity[property]["$XYZColumns"].push(column);
+					}
+				}
+				this._recursiveAssignColumns(data[property], entity[property].$XYZEntity);
+			}
+		}
+	}
+}

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/download/SpreadsheetDownload.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/download/SpreadsheetDownload.ts
@@ -26,12 +26,6 @@ export default class SpreadsheetDownload extends ManagedObject {
 		this.dataAssigner = new DataAssigner();
 	}
 
-	async downloadSpreadsheetFlatTemplate(entityDefinition: EntityDefinition, downloadTemplate: boolean, spreadsheetExportConfig: DeepDownloadConfig): Promise<void> {
-		await this.spreadsheetGenerator.generateFlatTemplate(entityDefinition, downloadTemplate, spreadsheetExportConfig);
-	}
-
-	getFlatSheet() {}
-
 	// Function to extract the properties from input config and metadata
 	async _extractProperties(proConfigColumns: any, entityMetadata: any, entityType: string): Promise<PropertyWithOrder[]> {
 		const labelList = await this.odataHandler.getLabelList([], entityType, this.component.getExcludeColumns());

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/download/SpreadsheetDownload.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/download/SpreadsheetDownload.ts
@@ -1,10 +1,11 @@
 import ManagedObject from "sap/ui/base/ManagedObject";
 import { EntityDefinition, EntityObject, PropertyWithOrder, DeepDownloadConfig } from "../../types";
-import * as XLSX from "xlsx";
 import SpreadsheetUpload from "../SpreadsheetUpload";
 import Component from "../../Component";
 import OData from "../odata/OData";
 import Util from "../Util";
+import SpreadsheetGenerator from "./SpreadsheetGenerator";
+import DataAssigner from "./DataAssigner";
 /**
  * @namespace cc.spreadsheetimporter.download.XXXnamespaceXXX
  */
@@ -12,204 +13,20 @@ export default class SpreadsheetDownload extends ManagedObject {
 	spreadsheetUploadController: SpreadsheetUpload;
 	component: Component;
 	odataHandler: OData;
+	private spreadsheetGenerator: SpreadsheetGenerator;
+	private dataAssigner: DataAssigner;
 
 	constructor(spreadsheetUploadController: SpreadsheetUpload, component: Component, odataHandler: OData) {
 		super();
 		this.spreadsheetUploadController = spreadsheetUploadController;
 		this.component = component;
 		this.odataHandler = odataHandler;
-	}
-
-	async downloadSpreadsheet(entityDefinition: EntityDefinition, spreadsheetExportConfig: DeepDownloadConfig): Promise<void> {
-		let filename = spreadsheetExportConfig.filename || this.spreadsheetUploadController.getOdataType() + ".xlsx";
-		const wb = XLSX.utils.book_new(); // creating the new spreadsheet work book
-
-		await this._appendRootEntitySheet(wb, entityDefinition, spreadsheetExportConfig);
-		if (spreadsheetExportConfig.deepExport) {
-			await this._appendSiblingsSheetsRecursively(wb, entityDefinition, entityDefinition, spreadsheetExportConfig);
-		}
-		// check if filename ends with .xlsx if not add it
-		if (!filename.endsWith(".xlsx")) {
-			filename = filename.concat(".xlsx");
-		}
-
-		// download the created spreadsheet file
-		XLSX.writeFile(wb, filename);
-		// MessageToast.show(this.util.geti18nText("downloadingTemplate"));
+		this.spreadsheetGenerator = new SpreadsheetGenerator(spreadsheetUploadController, component, odataHandler);
+		this.dataAssigner = new DataAssigner();
 	}
 
 	async downloadSpreadsheetFlatTemplate(entityDefinition: EntityDefinition, downloadTemplate: boolean, spreadsheetExportConfig: DeepDownloadConfig): Promise<void> {
-		const properties = await this._extractProperties(spreadsheetExportConfig.columns, entityDefinition, "root");
-		// Sort properties based on the order and then map to get the property names
-		const sortedProperties = properties.sort((a, b) => a.order - b.order).map((p) => p.name);
-		var worksheet = {} as XLSX.WorkSheet;
-		// loop over sorted properties and add them to the worksheet
-		for (let i = 0; i < sortedProperties.length; i++) {
-			worksheet[XLSX.utils.encode_cell({ c: i, r: 0 })] = { v: sortedProperties[i], t: "s" };
-		}
-		worksheet["!ref"] = XLSX.utils.encode_range({ s: { c: 0, r: 0 }, e: { c: sortedProperties.length - 1, r: 0 } });
-		const wb = XLSX.utils.book_new();
-		wb.SheetNames.push("Template");
-		wb.Sheets["Template"] = worksheet;
-		// download the created spreadsheet file
-		XLSX.writeFile(wb, "Template.xlsx");
-	}
-
-	async _appendRootEntitySheet(wb: XLSX.WorkBook, entityDefinition: EntityDefinition, spreadsheetExportConfig: DeepDownloadConfig): Promise<void> {
-		if (entityDefinition.$XYZData) {
-			const data = entityDefinition.$XYZData;
-			const labelList = await this.odataHandler.getLabelList([], this.spreadsheetUploadController.getOdataType(), this.component.getExcludeColumns());
-			if (spreadsheetExportConfig.addKeysToExport) {
-				this.odataHandler.addKeys(labelList, this.spreadsheetUploadController.getOdataType());
-			}
-			const sheet = this._getSheet(labelList, data, entityDefinition.SiblingEntity.$Type, spreadsheetExportConfig, entityDefinition["$XYZColumns"], undefined);
-			const sheetName = this.spreadsheetUploadController.getOdataType().split(".").pop();
-			if (wb.SheetNames.includes(sheetName)) {
-				sheetName.concat("_1");
-			}
-			XLSX.utils.book_append_sheet(wb, sheet, sheetName);
-		}
-	}
-
-	async _appendSiblingsSheetsRecursively(
-		wb: XLSX.WorkBook,
-		entityDefinition: EntityDefinition,
-		parentEntity: any,
-		spreadsheetExportConfig: DeepDownloadConfig
-	): Promise<void> {
-		for (const property in entityDefinition) {
-			const currentEntity = entityDefinition[property];
-
-			if (!currentEntity.$XYZFetchableEntity) continue;
-			if (!currentEntity.$XYZData) continue;
-
-			// if (currentEntity["$XYZColumns"] && currentEntity["$XYZColumns"].length > 0) {
-				const data = currentEntity.$XYZData;
-
-				const labelList = await this.odataHandler.getLabelList([], currentEntity.$Type, this.component.getExcludeColumns());
-				if (spreadsheetExportConfig.addKeysToExport) {
-					this.odataHandler.addKeys(labelList, currentEntity.$Type, parentEntity, currentEntity.$Partner);
-				}
-
-				const sheet = this._getSheet(labelList, data, currentEntity.$Type, spreadsheetExportConfig, currentEntity["$XYZColumns"], entityDefinition.SiblingEntity.$Type);
-				let sheetName = currentEntity.$Type.split(".").pop();
-				let suffix = 0;
-				let originalSheetName = sheetName;
-				let availableLength = 31 - ("_" + suffix).length;
-				sheetName = originalSheetName.substring(0, availableLength) + (suffix > 0 ? "_" + suffix : "");
-
-				while (wb.SheetNames.includes(sheetName)) {
-					suffix++;
-					availableLength = 31 - ("_" + suffix).length;
-					sheetName = originalSheetName.substring(0, availableLength) + "_" + suffix;
-				}
-
-				XLSX.utils.book_append_sheet(wb, sheet, sheetName);
-			// }
-
-			// Recursively append other nested navigation properties.
-			// Also, pass the current entity as parent for the next level.
-			await this._appendSiblingsSheetsRecursively(wb, currentEntity.$XYZEntity, entityDefinition, spreadsheetExportConfig);
-		}
-	}
-
-	_getSheet(labelList: any, dataArray: any, entityType: string, spreadsheetExportConfig: DeepDownloadConfig, columnsConfig: string[], parentEntityType?: string): XLSX.WorkSheet {
-		let rows = dataArray.length;
-		let fieldMatchType = this.component.getFieldMatchType();
-		var worksheet = {} as XLSX.WorkSheet;
-		let colWidths: { wch: number }[] = []; // array to store column widths
-		const colWidthDefault = 15;
-		const colWidthDate = 20;
-		let col = 0;
-		let startRow = 0;
-		// remove columns from map labelist that are not in the config
-		if (columnsConfig && columnsConfig.length > 0) {
-			for (let key of labelList.keys()) {
-				if (!columnsConfig.includes(key)) {
-					labelList.delete(key);
-				}
-			}
-		}
-		// add column headers and data
-		for (let [key, value] of labelList.entries()) {
-			let width = colWidthDefault;
-			let cell = { v: "", t: "s" } as XLSX.CellObject;
-			let label = "";
-			if (fieldMatchType === "label") {
-				label = value.label;
-			}
-			if (fieldMatchType === "labelTypeBrackets") {
-				label = `${value.label}[${key}]`;
-			}
-			worksheet[XLSX.utils.encode_cell({ c: col, r: startRow })] = { v: label, t: "s" };
-
-			for (const [index, data] of dataArray.entries()) {
-				let sampleDataValue = "";
-				rows = index + 1 + startRow;
-				if (data[key]) {
-					sampleDataValue = data[key];
-				} else {
-					worksheet[XLSX.utils.encode_cell({ c: col, r: rows })] = { v: "", t: "s" }; // Set the cell as empty
-					continue; // Move to the next iteration
-				}
-				if (value.type === "Edm.Boolean") {
-					cell = {
-						v: sampleDataValue.toString(),
-						t: "b"
-					};
-				} else if (value.type === "Edm.String" || value.type === "Edm.Guid" || value.type === "Edm.Any") {
-					cell = { v: sampleDataValue, t: "s" };
-				} else if (value.type === "Edm.DateTimeOffset" || value.type === "Edm.DateTime") {
-					let format;
-					const currentLang = sap.ui.getCore().getConfiguration().getLanguage();
-					if (currentLang.startsWith("en")) {
-						format = "mm/dd/yyyy hh:mm AM/PM";
-					} else {
-						format = "dd.mm.yyyy hh:mm";
-					}
-
-					cell = { v: sampleDataValue, t: "d", z: format };
-					width = colWidthDate;
-				} else if (value.type === "Edm.Date") {
-					cell = {
-						v: sampleDataValue,
-						t: "d"
-					};
-				} else if (value.type === "Edm.TimeOfDay" || value.type === "Edm.Time") {
-					cell = {
-						v: sampleDataValue,
-						t: "d",
-						z: "hh:mm"
-					};
-				} else if (
-					value.type === "Edm.UInt8" ||
-					value.type === "Edm.Int16" ||
-					value.type === "Edm.Int32" ||
-					value.type === "Edm.Integer" ||
-					value.type === "Edm.Int64" ||
-					value.type === "Edm.Integer64"
-				) {
-					cell = {
-						v: sampleDataValue,
-						t: "n"
-					};
-				} else if (value.type === "Edm.Double" || value.type === "Edm.Decimal") {
-					const decimalSeparator = this.component.getDecimalSeparator();
-					cell = {
-						v: sampleDataValue,
-						t: "n"
-					};
-				}
-
-				worksheet[XLSX.utils.encode_cell({ c: col, r: rows })] = cell;
-			}
-			colWidths.push({ wch: width });
-			col++;
-		}
-
-		worksheet["!ref"] = XLSX.utils.encode_range({ s: { c: 0, r: 0 }, e: { c: col - 1, r: dataArray.length + startRow } });
-		worksheet["!cols"] = colWidths; // assign the column widths to the worksheet
-		return worksheet;
+		await this.spreadsheetGenerator.generateFlatTemplate(entityDefinition, downloadTemplate, spreadsheetExportConfig);
 	}
 
 	getFlatSheet() {}
@@ -249,7 +66,7 @@ export default class SpreadsheetDownload extends ManagedObject {
 		return undefined; // if not found
 	}
 
-	public async _fetchData(deepDownloadConfig: DeepDownloadConfig) {
+	public async fetchData(deepDownloadConfig: DeepDownloadConfig) {
 		const { mainEntity, expands } = this.odataHandler.getODataEntitiesRecursive(this.spreadsheetUploadController.getOdataType(), deepDownloadConfig.deepLevel);
 		const batchSize = 1000;
 		const customBinding = this.odataHandler.getBindingFromBinding(this.spreadsheetUploadController.binding, expands);
@@ -257,73 +74,14 @@ export default class SpreadsheetDownload extends ManagedObject {
 		// Start fetching the batches
 		const totalResults = await this.odataHandler.fetchBatch(customBinding, batchSize);
 		const data = Util.extractObjects(totalResults);
-		this._recursiveAssignData(data, mainEntity);
-		this._recursiveAssignDataRoot(deepDownloadConfig.columns, mainEntity);
-		this._recursiveAssignColumnsRoot(deepDownloadConfig.columns, mainEntity);
-		this._recursiveAssignColumns(deepDownloadConfig.columns, mainEntity);
+		
+		// Use the DataAssigner for all data assignments
+		this.dataAssigner.assignData(data, mainEntity);
+		this.dataAssigner.assignDataRoot(deepDownloadConfig.columns, mainEntity);
+		this.dataAssigner.assignColumnsRoot(deepDownloadConfig.columns, mainEntity);
+		this.dataAssigner.assignColumns(deepDownloadConfig.columns, mainEntity);
+		
 		mainEntity.$XYZData = data;
 		return mainEntity;
-	}
-
-	private _recursiveAssignData(data: any, entity: any) {
-		// Iterate through properties of the current entity
-		for (const property in entity) {
-			// If the property signifies a fetchable entity
-			if (entity[property].$XYZFetchableEntity) {
-				let subEntityDataTotal = [];
-				for (const row in data) {
-					const currentEntity = data[row];
-					const subEntityData = currentEntity[property];
-					if (subEntityData) {
-						subEntityDataTotal = subEntityDataTotal.concat(subEntityData);
-					}
-					delete currentEntity[property]; // remove the data
-				}
-				entity[property].$XYZData = subEntityDataTotal;
-
-				// Recursive call to handle deeper levels
-				this._recursiveAssignData(subEntityDataTotal, entity[property].$XYZEntity);
-			}
-		}
-	}
-
-	private _recursiveAssignDataRoot(data: any, entity: any) {
-		// Iterate through properties of the current entity
-		entity.$XYZData = [];
-		let row = {};
-		for (const column in data) {
-			if (entity.hasOwnProperty(column) && !entity[column].$XYZFetchableEntity) {
-				if (!entity["$XYZColumns"]) entity["$XYZColumns"] = [];
-				row[column] = data[column];
-			}
-		}
-		entity.$XYZData.push(row);
-	}
-
-	private _recursiveAssignColumnsRoot(data: any, entity: any) {
-		for (const column in data) {
-			if (entity.hasOwnProperty(column) && !entity[column].$XYZFetchableEntity) {
-				if (!entity["$XYZColumns"]) entity["$XYZColumns"] = [];
-				entity["$XYZColumns"].push(column);
-			}
-		}
-	}
-
-	// function to assign columns to the sub entities
-	private _recursiveAssignColumns(data: any, entity: any) {
-		for (const property in entity) {
-			// If the property signifies a fetchable entity
-			if (entity[property].$XYZFetchableEntity && data.hasOwnProperty(property)) {
-				const subEntity = entity[property].$XYZEntity;
-				// Defined Columns in the pro config
-				for (const column in data[property]) {
-					if (subEntity.hasOwnProperty(column) && !subEntity[column].$XYZFetchableEntity) {
-						if (!entity[property]["$XYZColumns"]) entity[property]["$XYZColumns"] = [];
-						entity[property]["$XYZColumns"].push(column);
-					}
-				}
-				this._recursiveAssignColumns(data[property], entity[property].$XYZEntity);
-			}
-		}
 	}
 }

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/download/SpreadsheetDownload.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/download/SpreadsheetDownload.ts
@@ -6,6 +6,7 @@ import OData from "../odata/OData";
 import Util from "../Util";
 import SpreadsheetGenerator from "./SpreadsheetGenerator";
 import DataAssigner from "./DataAssigner";
+import Log from "sap/base/Log";
 /**
  * @namespace cc.spreadsheetimporter.download.XXXnamespaceXXX
  */
@@ -68,6 +69,9 @@ export default class SpreadsheetDownload extends ManagedObject {
 
 	public async fetchData(deepDownloadConfig: DeepDownloadConfig) {
 		const { mainEntity, expands } = this.odataHandler.getODataEntitiesRecursive(this.spreadsheetUploadController.getOdataType(), deepDownloadConfig.deepLevel);
+		// Log the mainEntity and expands
+		Log.debug("MainEntity:", mainEntity, "SpreadsheetDownload: fetchData");
+		Log.debug("Expands:", expands, "SpreadsheetDownload: fetchData");
 		const batchSize = 1000;
 		const customBinding = this.odataHandler.getBindingFromBinding(this.spreadsheetUploadController.binding, expands);
 

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/download/SpreadsheetDownloadDialog.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/download/SpreadsheetDownloadDialog.ts
@@ -31,7 +31,8 @@ export default class SpreadsheetDownloadDialog extends ManagedObject {
 		this.spreadsheetUploadController.view.setBusy(true);
 		if (!this.spreadsheetDownloadDialog) {
 			this.spreadsheetOptionsModel = new JSONModel(this.component.getDeepDownloadConfig());
-			this.spreadsheetOptionsModel.setProperty("/filename", this.spreadsheetUploadController.getOdataType());
+			const modelData = this.spreadsheetOptionsModel.getData();
+			this.spreadsheetOptionsModel.setProperty("/filename", modelData.filename || this.spreadsheetUploadController.getOdataType());
 			this.spreadsheetDownloadDialog = (await Fragment.load({
 				name: "cc.spreadsheetimporter.XXXnamespaceXXX.fragment.SpreadsheetDownload",
 				type: "XML",

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/download/SpreadsheetDownloadDialog.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/download/SpreadsheetDownloadDialog.ts
@@ -1,0 +1,59 @@
+import ManagedObject from "sap/ui/base/ManagedObject";
+import Dialog from "sap/m/Dialog";
+import Fragment from "sap/ui/core/Fragment";
+import JSONModel from "sap/ui/model/json/JSONModel";
+import SpreadsheetUpload from "../SpreadsheetUpload";
+import { DeepDownloadConfig } from "../../types";
+import SpreadsheetUploadDialog from "../dialog/SpreadsheetUploadDialog";
+import Util from "../Util";
+
+/**
+ * @namespace cc.spreadsheetimporter.download.XXXnamespaceXXX
+ */
+export default class SpreadsheetDownloadDialog extends ManagedObject {
+	spreadsheetUploadController: SpreadsheetUpload;
+	spreadsheetDownloadDialog: any;
+	spreadsheetOptionsModel: JSONModel;
+	componentI18n: any;
+	component: any;
+	spreadsheetUploadDialog: SpreadsheetUploadDialog;
+
+	constructor(spreadsheetUploadController: any, spreadsheetUploadDialog: SpreadsheetUploadDialog) {
+		super();
+		this.spreadsheetUploadDialog = spreadsheetUploadDialog;
+		this.spreadsheetUploadController = spreadsheetUploadController;
+		this.componentI18n = this.spreadsheetUploadController.componentI18n;
+		this.component = this.spreadsheetUploadController.component;
+	}
+
+	async createSpreadsheetDownloadDialog(): Promise<void> {
+		this.spreadsheetUploadController.view.setBusyIndicatorDelay(0);
+		this.spreadsheetUploadController.view.setBusy(true);
+		if (!this.spreadsheetDownloadDialog) {
+			this.spreadsheetOptionsModel = new JSONModel(this.component.getDeepDownloadConfig());
+			this.spreadsheetOptionsModel.setProperty("/filename", this.spreadsheetUploadController.getOdataType());
+			this.spreadsheetDownloadDialog = (await Fragment.load({
+				name: "cc.spreadsheetimporter.XXXnamespaceXXX.fragment.SpreadsheetDownload",
+				type: "XML",
+				controller: this
+			})) as Dialog;
+			this.spreadsheetDownloadDialog.setBusyIndicatorDelay(0);
+			this.spreadsheetDownloadDialog.setModel(this.componentI18n, "i18n");
+			this.spreadsheetDownloadDialog.setModel(this.spreadsheetOptionsModel, "spreadsheetOptions");
+			this.spreadsheetDownloadDialog.setModel(this.component.getModel("device"), "device");
+		}
+		this.spreadsheetUploadController.view.setBusy(false);
+	}
+
+	onSave() {
+		const deepDownloadConfig = this.spreadsheetDownloadDialog.getModel("spreadsheetOptions").getData() as DeepDownloadConfig;
+		const mergedConfig = Util.mergeConfig(this.component.getDeepDownloadConfig(), deepDownloadConfig);
+		this.component.setDeepDownloadConfig(mergedConfig);
+		this.spreadsheetUploadDialog.onDownloadDataSpreadsheet();
+		this.spreadsheetDownloadDialog.close();
+	}
+
+	onCancel() {
+		this.spreadsheetDownloadDialog.close();
+	}
+}

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/download/SpreadsheetGenerator.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/download/SpreadsheetGenerator.ts
@@ -1,0 +1,225 @@
+import ManagedObject from "sap/ui/base/ManagedObject";
+import * as XLSX from "xlsx";
+import { EntityDefinition, DeepDownloadConfig } from "../../types";
+import SpreadsheetUpload from "../SpreadsheetUpload";
+import Component from "../../Component";
+import OData from "../odata/OData";
+
+/**
+ * @namespace cc.spreadsheetimporter.download.XXXnamespaceXXX
+ */
+export default class SpreadsheetGenerator extends ManagedObject {
+    spreadsheetUploadController: SpreadsheetUpload;
+    component: Component;
+    odataHandler: OData;
+
+    constructor(spreadsheetUploadController: SpreadsheetUpload, component: Component, odataHandler: OData) {
+        super();
+        this.spreadsheetUploadController = spreadsheetUploadController;
+        this.component = component;
+        this.odataHandler = odataHandler;
+    }
+
+    async downloadSpreadsheet(entityDefinition: EntityDefinition, spreadsheetExportConfig: DeepDownloadConfig): Promise<void> {
+        let filename = spreadsheetExportConfig.filename || this.spreadsheetUploadController.getOdataType() + ".xlsx";
+        const wb = XLSX.utils.book_new(); // creating the new spreadsheet work book
+
+        await this._appendRootEntitySheet(wb, entityDefinition, spreadsheetExportConfig);
+        if (spreadsheetExportConfig.deepExport) {
+            await this._appendSiblingsSheetsRecursively(wb, entityDefinition, entityDefinition, spreadsheetExportConfig);
+        }
+        
+        // check if filename ends with .xlsx if not add it
+        if (!filename.endsWith(".xlsx")) {
+            filename = filename.concat(".xlsx");
+        }
+
+        // download the created spreadsheet file
+        XLSX.writeFile(wb, filename);
+    }
+
+    async generateFlatTemplate(entityDefinition: EntityDefinition, downloadTemplate: boolean, spreadsheetExportConfig: DeepDownloadConfig): Promise<void> {
+        const properties = await this._extractProperties(spreadsheetExportConfig.columns, entityDefinition, "root");
+        // Sort properties based on the order and then map to get the property names
+        const sortedProperties = properties.sort((a, b) => a.order - b.order).map((p) => p.name);
+        var worksheet = {} as XLSX.WorkSheet;
+        // loop over sorted properties and add them to the worksheet
+        for (let i = 0; i < sortedProperties.length; i++) {
+            worksheet[XLSX.utils.encode_cell({ c: i, r: 0 })] = { v: sortedProperties[i], t: "s" };
+        }
+        worksheet["!ref"] = XLSX.utils.encode_range({ s: { c: 0, r: 0 }, e: { c: sortedProperties.length - 1, r: 0 } });
+        const wb = XLSX.utils.book_new();
+        wb.SheetNames.push("Template");
+        wb.Sheets["Template"] = worksheet;
+        // download the created spreadsheet file
+        XLSX.writeFile(wb, "Template.xlsx");
+    }
+
+    private async _appendRootEntitySheet(wb: XLSX.WorkBook, entityDefinition: EntityDefinition, spreadsheetExportConfig: DeepDownloadConfig): Promise<void> {
+        if (entityDefinition.$XYZData) {
+            const data = entityDefinition.$XYZData;
+            const labelList = await this.odataHandler.getLabelList([], this.spreadsheetUploadController.getOdataType(), this.component.getExcludeColumns());
+            if (spreadsheetExportConfig.addKeysToExport) {
+                this.odataHandler.addKeys(labelList, this.spreadsheetUploadController.getOdataType());
+            }
+            const sheet = this._getSheet(labelList, data, entityDefinition.SiblingEntity.$Type, spreadsheetExportConfig, entityDefinition["$XYZColumns"], undefined);
+            const sheetName = this.spreadsheetUploadController.getOdataType().split(".").pop();
+            if (wb.SheetNames.includes(sheetName)) {
+                sheetName.concat("_1");
+            }
+            XLSX.utils.book_append_sheet(wb, sheet, sheetName);
+        }
+    }
+
+    private async _appendSiblingsSheetsRecursively(
+        wb: XLSX.WorkBook,
+        entityDefinition: EntityDefinition,
+        parentEntity: any,
+        spreadsheetExportConfig: DeepDownloadConfig
+    ): Promise<void> {
+        for (const property in entityDefinition) {
+            const currentEntity = entityDefinition[property];
+
+            if (!currentEntity.$XYZFetchableEntity) continue;
+            if (!currentEntity.$XYZData) continue;
+
+            const data = currentEntity.$XYZData;
+            const labelList = await this.odataHandler.getLabelList([], currentEntity.$Type, this.component.getExcludeColumns());
+            if (spreadsheetExportConfig.addKeysToExport) {
+                this.odataHandler.addKeys(labelList, currentEntity.$Type, parentEntity, currentEntity.$Partner);
+            }
+
+            const sheet = this._getSheet(labelList, data, currentEntity.$Type, spreadsheetExportConfig, currentEntity["$XYZColumns"], entityDefinition.SiblingEntity.$Type);
+            let sheetName = currentEntity.$Type.split(".").pop();
+            let suffix = 0;
+            let originalSheetName = sheetName;
+            let availableLength = 31 - ("_" + suffix).length;
+            sheetName = originalSheetName.substring(0, availableLength) + (suffix > 0 ? "_" + suffix : "");
+
+            while (wb.SheetNames.includes(sheetName)) {
+                suffix++;
+                availableLength = 31 - ("_" + suffix).length;
+                sheetName = originalSheetName.substring(0, availableLength) + "_" + suffix;
+            }
+
+            XLSX.utils.book_append_sheet(wb, sheet, sheetName);
+
+            // Recursively append other nested navigation properties.
+            // Also, pass the current entity as parent for the next level.
+            await this._appendSiblingsSheetsRecursively(wb, currentEntity.$XYZEntity, entityDefinition, spreadsheetExportConfig);
+        }
+    }
+
+    private _getSheet(labelList: any, dataArray: any, entityType: string, spreadsheetExportConfig: DeepDownloadConfig, columnsConfig: string[], parentEntityType?: string): XLSX.WorkSheet {
+        let rows = dataArray.length;
+        let fieldMatchType = this.component.getFieldMatchType();
+        var worksheet = {} as XLSX.WorkSheet;
+        let colWidths: { wch: number }[] = []; // array to store column widths
+        const colWidthDefault = 15;
+        const colWidthDate = 20;
+        let col = 0;
+        let startRow = 0;
+        
+        // remove columns from map labelist that are not in the config
+        if (columnsConfig && columnsConfig.length > 0) {
+            for (let key of labelList.keys()) {
+                const label = labelList.get(key);
+                if (!columnsConfig.includes(key) && !label?.$XYZKey) {
+                    labelList.delete(key);
+                }
+            }
+        }
+
+        // add column headers and data
+        for (let [key, value] of labelList.entries()) {
+            let width = colWidthDefault;
+            let cell = { v: "", t: "s" } as XLSX.CellObject;
+            let label = "";
+            if (fieldMatchType === "label") {
+                label = value.label;
+            }
+            if (fieldMatchType === "labelTypeBrackets") {
+                label = `${value.label}[${key}]`;
+            }
+            worksheet[XLSX.utils.encode_cell({ c: col, r: startRow })] = { v: label, t: "s" };
+
+            for (const [index, data] of dataArray.entries()) {
+                let sampleDataValue = "";
+                rows = index + 1 + startRow;
+                if (data[key]) {
+                    sampleDataValue = data[key];
+                } else {
+                    worksheet[XLSX.utils.encode_cell({ c: col, r: rows })] = { v: "", t: "s" }; // Set the cell as empty
+                    continue; // Move to the next iteration
+                }
+
+                cell = this._getCellForType(value.type, sampleDataValue);
+                if (value.type === "Edm.DateTimeOffset" || value.type === "Edm.DateTime") {
+                    width = colWidthDate;
+                }
+
+                worksheet[XLSX.utils.encode_cell({ c: col, r: rows })] = cell;
+            }
+            colWidths.push({ wch: width });
+            col++;
+        }
+
+        worksheet["!ref"] = XLSX.utils.encode_range({ s: { c: 0, r: 0 }, e: { c: col - 1, r: dataArray.length + startRow } });
+        worksheet["!cols"] = colWidths; // assign the column widths to the worksheet
+        return worksheet;
+    }
+
+    private _getCellForType(type: string, value: any): XLSX.CellObject {
+        switch (type) {
+            case "Edm.Boolean":
+                return { v: value.toString(), t: "b" };
+            case "Edm.String":
+            case "Edm.Guid":
+            case "Edm.Any":
+                return { v: value, t: "s" };
+            case "Edm.DateTimeOffset":
+            case "Edm.DateTime":
+                const currentLang = sap.ui.getCore().getConfiguration().getLanguage();
+                const format = currentLang.startsWith("en") ? "mm/dd/yyyy hh:mm AM/PM" : "dd.mm.yyyy hh:mm";
+                return { v: value, t: "d", z: format };
+            case "Edm.Date":
+                return { v: value, t: "d" };
+            case "Edm.TimeOfDay":
+            case "Edm.Time":
+                return { v: value, t: "d", z: "hh:mm" };
+            case "Edm.UInt8":
+            case "Edm.Int16":
+            case "Edm.Int32":
+            case "Edm.Integer":
+            case "Edm.Int64":
+            case "Edm.Integer64":
+            case "Edm.Double":
+            case "Edm.Decimal":
+                return { v: value, t: "n" };
+            default:
+                return { v: value, t: "s" };
+        }
+    }
+
+    private async _extractProperties(proConfigColumns: any, entityMetadata: any, entityType: string): Promise<PropertyWithOrder[]> {
+        const labelList = await this.odataHandler.getLabelList([], entityType, this.component.getExcludeColumns());
+        let properties: PropertyWithOrder[] = [];
+
+        for (let prop in proConfigColumns) {
+            if (proConfigColumns[prop].order !== undefined && proConfigColumns[prop].data !== undefined && entityMetadata[prop]) {
+                const label = labelList.get(prop);
+                let headerName: string;
+                if (label) {
+                    headerName = `${label.label} [${entityType.split(".").pop()}][${prop}]`;
+                } else {
+                    headerName = `${prop} [${entityType.split(".").pop()}][${prop}]`;
+                }
+                properties.push({ name: headerName, order: proConfigColumns[prop].order });
+            } else if (typeof proConfigColumns[prop] === "object") {
+                properties = properties.concat(await this._extractProperties(proConfigColumns[prop], entityMetadata[prop].$XYZEntity, entityMetadata[prop].$Type));
+            }
+        }
+
+        return properties;
+    }
+}

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/download/SpreadsheetGenerator.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/download/SpreadsheetGenerator.ts
@@ -5,6 +5,7 @@ import SpreadsheetUpload from "../SpreadsheetUpload";
 import Component from "../../Component";
 import OData from "../odata/OData";
 import Util from "../Util";
+import Log from "sap/base/Log";
 
 /**
  * @namespace cc.spreadsheetimporter.download.XXXnamespaceXXX
@@ -35,6 +36,19 @@ export default class SpreadsheetGenerator extends ManagedObject {
         // check if filename ends with .xlsx if not add it
         if (!filename.endsWith(".xlsx")) {
             filename = filename.concat(".xlsx");
+        }
+
+        let isDefaultPrevented = false;
+
+        try {
+            const asyncEventBeforeDownloadFileExport = await Util.fireEventAsync("beforeDownloadFileExport", { workbook: wb, filename: filename }, this.component);
+            isDefaultPrevented = asyncEventBeforeDownloadFileExport.bPreventDefault;
+        } catch (error) {
+            Log.error("Error while calling the beforeDownloadFileExport event", error as Error, "SpreadsheetGenerator.ts", "downloadSpreadsheet");
+        }
+
+        if (isDefaultPrevented) {
+            return;
         }
 
         // download the created spreadsheet file

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/download/SpreadsheetGenerator.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/download/SpreadsheetGenerator.ts
@@ -4,6 +4,7 @@ import { EntityDefinition, DeepDownloadConfig } from "../../types";
 import SpreadsheetUpload from "../SpreadsheetUpload";
 import Component from "../../Component";
 import OData from "../odata/OData";
+import Util from "../Util";
 
 /**
  * @namespace cc.spreadsheetimporter.download.XXXnamespaceXXX
@@ -12,6 +13,7 @@ export default class SpreadsheetGenerator extends ManagedObject {
     spreadsheetUploadController: SpreadsheetUpload;
     component: Component;
     odataHandler: OData;
+    currentLang: string;
 
     constructor(spreadsheetUploadController: SpreadsheetUpload, component: Component, odataHandler: OData) {
         super();
@@ -21,6 +23,7 @@ export default class SpreadsheetGenerator extends ManagedObject {
     }
 
     async downloadSpreadsheet(entityDefinition: EntityDefinition, spreadsheetExportConfig: DeepDownloadConfig): Promise<void> {
+        this.currentLang = await Util.getLanguage();
         let filename = spreadsheetExportConfig.filename || this.spreadsheetUploadController.getOdataType() + ".xlsx";
         const wb = XLSX.utils.book_new(); // creating the new spreadsheet work book
 
@@ -162,8 +165,7 @@ export default class SpreadsheetGenerator extends ManagedObject {
                 return { v: value, t: "s" };
             case "Edm.DateTimeOffset":
             case "Edm.DateTime":
-                const currentLang = sap.ui.getCore().getConfiguration().getLanguage();
-                const format = currentLang.startsWith("en") ? "mm/dd/yyyy hh:mm AM/PM" : "dd.mm.yyyy hh:mm";
+                const format = this.currentLang.startsWith("en") ? "mm/dd/yyyy hh:mm AM/PM" : "dd.mm.yyyy hh:mm";
                 return { v: value, t: "d", z: format };
             case "Edm.Date":
                 return { v: value, t: "d" };

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/download/SpreadsheetGenerator.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/download/SpreadsheetGenerator.ts
@@ -38,23 +38,6 @@ export default class SpreadsheetGenerator extends ManagedObject {
         XLSX.writeFile(wb, filename);
     }
 
-    async generateFlatTemplate(entityDefinition: EntityDefinition, downloadTemplate: boolean, spreadsheetExportConfig: DeepDownloadConfig): Promise<void> {
-        const properties = await this._extractProperties(spreadsheetExportConfig.columns, entityDefinition, "root");
-        // Sort properties based on the order and then map to get the property names
-        const sortedProperties = properties.sort((a, b) => a.order - b.order).map((p) => p.name);
-        var worksheet = {} as XLSX.WorkSheet;
-        // loop over sorted properties and add them to the worksheet
-        for (let i = 0; i < sortedProperties.length; i++) {
-            worksheet[XLSX.utils.encode_cell({ c: i, r: 0 })] = { v: sortedProperties[i], t: "s" };
-        }
-        worksheet["!ref"] = XLSX.utils.encode_range({ s: { c: 0, r: 0 }, e: { c: sortedProperties.length - 1, r: 0 } });
-        const wb = XLSX.utils.book_new();
-        wb.SheetNames.push("Template");
-        wb.Sheets["Template"] = worksheet;
-        // download the created spreadsheet file
-        XLSX.writeFile(wb, "Template.xlsx");
-    }
-
     private async _appendRootEntitySheet(wb: XLSX.WorkBook, entityDefinition: EntityDefinition, spreadsheetExportConfig: DeepDownloadConfig): Promise<void> {
         if (entityDefinition.$XYZData) {
             const data = entityDefinition.$XYZData;

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/odata/MetadataHandler.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/odata/MetadataHandler.ts
@@ -36,4 +36,5 @@ export default abstract class MetadataHandler extends ManagedObject {
 
 	abstract getLabelList(columns: Columns, odataType: string, odataEntityType: any, excludeColumns: Columns): ListObject;
 	abstract getKeyList(odataEntityType: any): string[];
+	abstract getODataEntitiesRecursive(entityName: string, deepLevel: number): any;
 }

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/odata/MetadataHandlerV2.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/odata/MetadataHandlerV2.ts
@@ -141,4 +141,8 @@ export default class MetadataHandlerV2 extends MetadataHandler {
 		}
 		return keys;
 	}
+
+	getODataEntitiesRecursive(entityName: string, deepLevel: number): any {
+		throw new Error("Method not implemented.");
+	}
 }

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/odata/MetadataHandlerV4.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/odata/MetadataHandlerV4.ts
@@ -256,8 +256,7 @@ export default class MetadataHandlerV4 extends MetadataHandler {
 	 * @param partner 
 	 */
 	addKeys(labelList: ListObject, entityName: string, parentEntity?: any, partner?: string) {
-		const annotations = this.spreadsheetUploadController.context.getModel().getMetaModel().getData()["$Annotations"];
-		const properties = this.spreadsheetUploadController.context.getModel().getMetaModel().getData()[entityName];
+		const { annotations, properties } = MetadataHandlerV4.getAnnotationProperties(this.spreadsheetUploadController.context, entityName);
 		const keys = [];
 		// if parentEntity is set, we need to get the key from the parent Entity
 		if (parentEntity) {

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/odata/MetadataHandlerV4.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/odata/MetadataHandlerV4.ts
@@ -175,7 +175,7 @@ export default class MetadataHandlerV4 extends MetadataHandler {
 		const entities: any = this.spreadsheetUploadController.binding.getModel().getMetaModel().getData();
 
 		if (!entities || !entities[entityName]) {
-			throw new Error("Entity not found"); // Add appropriate error message and handling
+			throw new Error(`Entity '${entityName}' not found`); // Add appropriate error message and handling
 		}
 
 		const mainEntity: any = entities[entityName];

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/odata/OData.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/odata/OData.ts
@@ -11,6 +11,8 @@ import JSONModel from "sap/ui/model/json/JSONModel";
 import Fragment from "sap/ui/core/Fragment";
 import Dialog from "sap/m/Dialog";
 import Util from "../Util";
+import ODataListBindingV2 from "sap/ui/model/odata/v2/ODataListBinding";
+import ODataListBindingV4 from "sap/ui/model/odata/v4/ODataListBinding";
 
 /**
  * @namespace cc.spreadsheetimporter.XXXnamespaceXXX
@@ -246,6 +248,10 @@ export default abstract class OData extends ManagedObject {
 	abstract getOdataType(binding: any, odataType: any): string;
 	abstract checkForErrors(model: any, binding: any, showBackendErrorMessages: Boolean): Promise<boolean>;
 	abstract createCustomBinding(binding: any): any;
-
+	abstract getODataEntitiesRecursive(entityName: string, deepLevel: number): any;
+	abstract getBindingFromBinding(binding: any, expand?: any): ODataListBindingV4 | ODataListBindingV2;
+	abstract fetchBatch(customBinding: ODataListBindingV4 | ODataListBindingV2, batchSize: number): Promise<any>;
+	abstract addKeys(labelList: ListObject, entityName: string, parentEntity?: any, partner?: string): void;
+	
 	// Pro Methods
 }

--- a/packages/ui5-cc-spreadsheetimporter/src/controller/odata/ODataV2.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/controller/odata/ODataV2.ts
@@ -159,4 +159,18 @@ export default class ODataV2 extends OData {
 	getMetadataHandler(): MetadataHandlerV2 {
 		return this.metadataHandler;
 	}
+
+	getODataEntitiesRecursive(entityName: string, deepLevel: number): any {
+		return this.metadataHandler.getODataEntitiesRecursive(entityName, deepLevel);
+	}
+
+	getBindingFromBinding(binding: ODataListBinding, expand?: any): ODataListBinding {
+		throw new Error("Method not implemented.");
+	}
+
+	fetchBatch(customBinding: ODataListBinding, batchSize: number): Promise<any>{
+		throw new Error("Method not implemented.");
+	}
+
+	addKeys(labelList: ListObject, entityName: string, parentEntity?: any, partner?: string) {}
 }

--- a/packages/ui5-cc-spreadsheetimporter/src/fragment/SpreadsheetDownload.fragment.xml
+++ b/packages/ui5-cc-spreadsheetimporter/src/fragment/SpreadsheetDownload.fragment.xml
@@ -1,0 +1,28 @@
+<core:FragmentDefinition xmlns="sap.m" xmlns:core="sap.ui.core" xmlns:upload="sap.ui.unified" xmlns:f="sap.ui.layout.form">
+    <Dialog contentWidth="{= ${device>/system/phone} ? '100%' : '20vw' }" contentHeight="auto" verticalScrolling="false">
+        <customHeader>
+            <OverflowToolbar>
+                <Title text="{i18n>spreadsheetimporter.spreadsheetDownloadOptionsDialogTitle}" />
+                <ToolbarSpacer />
+            </OverflowToolbar>
+        </customHeader>
+        <content>
+            <f:SimpleForm editable="true" layout="ResponsiveGridLayout" labelSpanXL="3" labelSpanL="3" labelSpanM="3" labelSpanS="12" adjustLabelSpan="false" class="centered">
+                <f:content>
+                    <Label text="{i18n>spreadsheetimporter.spreadsheetDownloadDialogFilename}" />
+                    <Input value="{spreadsheetOptions>/filename}" />
+                    <Label text="{i18n>spreadsheetimporter.spreadsheetDownloadDialogForeignKeys}" />
+                    <CheckBox selected="{spreadsheetOptions>/addKeysToExport}" />
+                    <Label text="{i18n>spreadsheetimporter.spreadsheetDownloadDialogDeepExport}" />
+                    <CheckBox selected="{spreadsheetOptions>/deepExport}" />
+                    <Label text="{i18n>spreadsheetimporter.spreadsheetDownloadDialogDeepLevel}" />
+                    <Input value="{spreadsheetOptions>/deepLevel}" />
+                </f:content>
+            </f:SimpleForm>
+        </content>
+        <buttons>
+            <Button text="{i18n>spreadsheetimporter.startDownloadingSpreadsheet}" press=".onSave" type="Emphasized" />
+            <Button text="{i18n>spreadsheetimporter.closeSpreadsheetDownloadDialog}" press=".onCancel" />
+        </buttons>
+    </Dialog>
+</core:FragmentDefinition>

--- a/packages/ui5-cc-spreadsheetimporter/src/fragment/SpreadsheetUpload.fragment.xml
+++ b/packages/ui5-cc-spreadsheetimporter/src/fragment/SpreadsheetUpload.fragment.xml
@@ -9,6 +9,13 @@
         <Title text="{i18n>spreadsheetimporter.spreadsheetupload}" />
         <ToolbarSpacer />
         <Button press="showPreview" text="{i18n>spreadsheetimporter.showPreview}" visible="{= !${info>/hidePreview}}" enabled="{= ${info>/dataRows} > 0}" />
+        <Button press="onInitDownloadSpreadsheetProcess" 
+               text="{i18n>spreadsheetimporter.downloadDataSpreadsheet}" 
+               visible="{= ${info>/showDownload}}">
+               <layoutData>
+                <OverflowToolbarLayoutData priority="AlwaysOverflow"/>
+              </layoutData>
+        </Button>
         <Button press="onTempDownload" text="{i18n>spreadsheetimporter.downloadTemplate}" visible="{= !${info>/hideGenerateTemplateButton}}" />
         <Button press="onOpenOptionsDialog" icon="sap-icon://action-settings" visible="{= ${info>/showOptions}}" />
       </OverflowToolbar>

--- a/packages/ui5-cc-spreadsheetimporter/src/fragment/SpreadsheetUpload.fragment.xml
+++ b/packages/ui5-cc-spreadsheetimporter/src/fragment/SpreadsheetUpload.fragment.xml
@@ -11,7 +11,7 @@
         <Button press="showPreview" text="{i18n>spreadsheetimporter.showPreview}" visible="{= !${info>/hidePreview}}" enabled="{= ${info>/dataRows} > 0}" />
         <Button press="onInitDownloadSpreadsheetProcess" 
                text="{i18n>spreadsheetimporter.downloadDataSpreadsheet}" 
-               visible="{= ${info>/showDownload}}">
+               visible="{= ${info>/showDownloadButton}}">
                <layoutData>
                 <OverflowToolbarLayoutData priority="AlwaysOverflow"/>
               </layoutData>

--- a/packages/ui5-cc-spreadsheetimporter/src/i18n/i18n_de.properties
+++ b/packages/ui5-cc-spreadsheetimporter/src/i18n/i18n_de.properties
@@ -12,6 +12,16 @@ spreadsheetimporter.showPreview=Vorschau anzeigen
 spreadsheetimporter.dataRows=<strong>{0}</strong> Datensätze stehen zu hochladen bereit
 spreadsheetimporter.showOptionMenu=Optionen anzeigen
 spreadsheetimporter.dropMessage=Datei hier ablegen
+spreadsheetimporter.downloadDataSpreadsheet=Daten als Spreadsheet herunterladen
+
+# Spreadsheet Download Option Dialog
+spreadsheetimporter.spreadsheetDownloadOptionsDialogTitle=Spreadsheet Download Options
+spreadsheetimporter.spreadsheetDownloadDialogFilename=Dateiname
+spreadsheetimporter.spreadsheetDownloadDialogForeignKeys=Fremdschlüssel hinzufügen
+spreadsheetimporter.spreadsheetDownloadDialogDeepExport=Tiefer Export
+spreadsheetimporter.spreadsheetDownloadDialogDeepLevel=Ebenen für den tiefen Export
+spreadsheetimporter.startDownloadingSpreadsheet=Spreadsheet herunterladen
+spreadsheetimporter.closeSpreadsheetDownloadDialog=Abbrechen
 
 # Spreadsheet Upload Dialog - Class
 spreadsheetimporter.selectFileUpload=Datei zum Hochladen auswählen

--- a/packages/ui5-cc-spreadsheetimporter/src/i18n/i18n_en.properties
+++ b/packages/ui5-cc-spreadsheetimporter/src/i18n/i18n_en.properties
@@ -12,6 +12,16 @@ spreadsheetimporter.showPreview=Show preview
 spreadsheetimporter.dataRows=<strong>{0}</strong> records are ready for upload
 spreadsheetimporter.showOptionMenu=Show options
 spreadsheetimporter.dropMessage=Drop file here
+spreadsheetimporter.downloadDataSpreadsheet=Download Data as Spreadsheet
+
+# Spreadsheet Download Option Dialog
+spreadsheetimporter.spreadsheetDownloadOptionsDialogTitle=Spreadsheet Download Options
+spreadsheetimporter.spreadsheetDownloadDialogFilename=Filename
+spreadsheetimporter.spreadsheetDownloadDialogForeignKeys=Add Keys
+spreadsheetimporter.spreadsheetDownloadDialogDeepExport=Deep Export
+spreadsheetimporter.spreadsheetDownloadDialogDeepLevel=Levels for Deep Export
+spreadsheetimporter.startDownloadingSpreadsheet=Download Spreadsheet
+spreadsheetimporter.closeSpreadsheetDownloadDialog=Cancel
 
 # Spreadsheet Upload Dialog - Class
 spreadsheetimporter.selectFileUpload=Select file to upload

--- a/packages/ui5-cc-spreadsheetimporter/src/i18n/i18n_es.properties
+++ b/packages/ui5-cc-spreadsheetimporter/src/i18n/i18n_es.properties
@@ -12,6 +12,16 @@ spreadsheetimporter.showPreview=Mostrar vista previa
 spreadsheetimporter.dataRows=<strong>{0}</strong> registros están listos para subir
 spreadsheetimporter.showOptionMenu=Mostrar opciones
 spreadsheetimporter.dropMessage=Suelta el archivo aquí
+spreadsheetimporter.downloadDataSpreadsheet=Descargar datos en hoja de cálculo
+
+# Spreadsheet Download Option Dialog
+spreadsheetimporter.spreadsheetDownloadOptionsDialogTitle=Opciones de descarga de hoja de cálculo
+spreadsheetimporter.spreadsheetDownloadDialogFilename=Nombre del archivo
+spreadsheetimporter.spreadsheetDownloadDialogForeignKeys=Agregar llaves
+spreadsheetimporter.spreadsheetDownloadDialogDeepExport=Exportación profunda
+spreadsheetimporter.spreadsheetDownloadDialogDeepLevel=Niveles para la exportación profunda
+spreadsheetimporter.startDownloadingSpreadsheet=Descargar hoja de cálculo
+spreadsheetimporter.closeSpreadsheetDownloadDialog=Cancelar
 
 # Spreadsheet Upload Dialog - Class
 spreadsheetimporter.selectFileUpload=Seleccione archivo para cargar

--- a/packages/ui5-cc-spreadsheetimporter/src/i18n/i18n_fr.properties
+++ b/packages/ui5-cc-spreadsheetimporter/src/i18n/i18n_fr.properties
@@ -12,6 +12,16 @@ spreadsheetimporter.showPreview=Afficher l`aperçu
 spreadsheetimporter.dataRows=<strong>{0}</strong> enregistrements sont prêts à être téléchargés
 spreadsheetimporter.showOptionMenu=Afficher les options
 spreadsheetimporter.dropMessage=Déposez le fichier ici
+spreadsheetimporter.downloadDataSpreadsheet=Télécharger les données en tant que feuille de calcul
+
+# Spreadsheet Download Option Dialog
+spreadsheetimporter.spreadsheetDownloadOptionsDialogTitle=Options de téléchargement de feuille de calcul
+spreadsheetimporter.spreadsheetDownloadDialogFilename=Nom de fichier
+spreadsheetimporter.spreadsheetDownloadDialogForeignKeys=Ajouter des clés
+spreadsheetimporter.spreadsheetDownloadDialogDeepExport=Exportation en profondeur
+spreadsheetimporter.spreadsheetDownloadDialogDeepLevel=Niveaux pour l`exportation en profondeur
+spreadsheetimporter.startDownloadingSpreadsheet=Télécharger la feuille de calcul
+spreadsheetimporter.closeSpreadsheetDownloadDialog=Annuler
 
 # Spreadsheet Upload Dialog - Class
 spreadsheetimporter.selectFileUpload=Sélectionnez le fichier à télécharger

--- a/packages/ui5-cc-spreadsheetimporter/src/i18n/i18n_hi.properties
+++ b/packages/ui5-cc-spreadsheetimporter/src/i18n/i18n_hi.properties
@@ -12,6 +12,16 @@ spreadsheetimporter.showPreview=पूर्वावलोकन दिखा�
 spreadsheetimporter.dataRows=<strong>{0}</strong> रिकॉर्ड अपलोड के लिए तैयार हैं
 spreadsheetimporter.showOptionMenu=विकल्प दिखाएँ
 spreadsheetimporter.dropMessage=यहाँ फाइल ड्रॉप करें
+spreadsheetimporter.downloadDataSpreadsheet=स्प्रेडशीट के रूप में डेटा डाउनलोड करें
+
+# Spreadsheet Download Option Dialog
+spreadsheetimporter.spreadsheetDownloadOptionsDialogTitle=स्प्रेडशीट डाउनलोड विकल्प
+spreadsheetimporter.spreadsheetDownloadDialogFilename=फ़ाइल का नाम
+spreadsheetimporter.spreadsheetDownloadDialogForeignKeys=कुंजी जोड़ें
+spreadsheetimporter.spreadsheetDownloadDialogDeepExport=गहरा निर्यात
+spreadsheetimporter.spreadsheetDownloadDialogDeepLevel=गहरे निर्यात के लिए स्तर
+spreadsheetimporter.startDownloadingSpreadsheet=स्प्रेडशीट डाउनलोड करें
+spreadsheetimporter.closeSpreadsheetDownloadDialog=रद्द करें
 
 # Spreadsheet Upload Dialog - Class
 spreadsheetimporter.selectFileUpload=अपलोड करने के लिए फ़ाइल का चयन करें

--- a/packages/ui5-cc-spreadsheetimporter/src/i18n/i18n_it.properties
+++ b/packages/ui5-cc-spreadsheetimporter/src/i18n/i18n_it.properties
@@ -12,6 +12,16 @@ spreadsheetimporter.showPreview=Mostra anteprima
 spreadsheetimporter.dataRows=<strong>{0}</strong> record sono pronti per essere caricati
 spreadsheetimporter.showOptionMenu=Mostra opzioni
 spreadsheetimporter.dropMessage=Trascina qui il file
+spreadsheetimporter.downloadDataSpreadsheet=Scarica dati come foglio di calcolo
+
+# Spreadsheet Download Option Dialog
+spreadsheetimporter.spreadsheetDownloadOptionsDialogTitle=Opzioni di download del foglio di calcolo
+spreadsheetimporter.spreadsheetDownloadDialogFilename=Nome del file
+spreadsheetimporter.spreadsheetDownloadDialogForeignKeys=Aggiungi chiavi
+spreadsheetimporter.spreadsheetDownloadDialogDeepExport=Esportazione profonda
+spreadsheetimporter.spreadsheetDownloadDialogDeepLevel=Livelli per l`esportazione profonda
+spreadsheetimporter.startDownloadingSpreadsheet=Scarica foglio di calcolo
+spreadsheetimporter.closeSpreadsheetDownloadDialog=Annulla
 
 # Spreadsheet Upload Dialog - Class
 spreadsheetimporter.selectFileUpload=Seleziona il file da caricare

--- a/packages/ui5-cc-spreadsheetimporter/src/i18n/i18n_ja.properties
+++ b/packages/ui5-cc-spreadsheetimporter/src/i18n/i18n_ja.properties
@@ -12,6 +12,16 @@ spreadsheetimporter.showPreview=プレビューを表示
 spreadsheetimporter.dataRows=<strong>{0}</strong> レコードがアップロードの準備ができています
 spreadsheetimporter.showOptionMenu=オプションを表示
 spreadsheetimporter.dropMessage=ここにファイルをドロップ
+spreadsheetimporter.downloadDataSpreadsheet=スプレッドシートとしてデータをダウンロード
+
+# Spreadsheet Download Option Dialog
+spreadsheetimporter.spreadsheetDownloadOptionsDialogTitle=スプレッドシートのダウンロードオプション
+spreadsheetimporter.spreadsheetDownloadDialogFilename=ファイル名
+spreadsheetimporter.spreadsheetDownloadDialogForeignKeys=キーを追加
+spreadsheetimporter.spreadsheetDownloadDialogDeepExport=深いエクスポート
+spreadsheetimporter.spreadsheetDownloadDialogDeepLevel=深いエクスポートのためのレベル
+spreadsheetimporter.startDownloadingSpreadsheet=スプレッドシートをダウンロード
+spreadsheetimporter.closeSpreadsheetDownloadDialog=キャンセル
 
 # Spreadsheet Upload Dialog - Class
 spreadsheetimporter.selectFileUpload=アップロードするファイルを選択

--- a/packages/ui5-cc-spreadsheetimporter/src/i18n/i18n_nl.properties
+++ b/packages/ui5-cc-spreadsheetimporter/src/i18n/i18n_nl.properties
@@ -12,6 +12,16 @@ spreadsheetimporter.showPreview=Toon voorbeeld
 spreadsheetimporter.dataRows=<strong>{0}</strong> records zijn klaar om te uploaden
 spreadsheetimporter.showOptionMenu=Toon opties
 spreadsheetimporter.dropMessage=Plaats bestand hier
+spreadsheetimporter.downloadDataSpreadsheet=Gegevens downloaden als Spreadsheet
+
+# Spreadsheet Download Option Dialog
+spreadsheetimporter.spreadsheetDownloadOptionsDialogTitle=Spreadsheet Download Opties
+spreadsheetimporter.spreadsheetDownloadDialogFilename=Bestandsnaam
+spreadsheetimporter.spreadsheetDownloadDialogForeignKeys=Sleutels toevoegen
+spreadsheetimporter.spreadsheetDownloadDialogDeepExport=Diepe Export
+spreadsheetimporter.spreadsheetDownloadDialogDeepLevel=Niveaus voor Diepe Export
+spreadsheetimporter.startDownloadingSpreadsheet=Spreadsheet downloaden
+spreadsheetimporter.closeSpreadsheetDownloadDialog=Annuleren
 
 # Spreadsheet Upload Dialog - Class
 spreadsheetimporter.selectFileUpload=Selecteer bestand om te uploaden

--- a/packages/ui5-cc-spreadsheetimporter/src/i18n/i18n_pt.properties
+++ b/packages/ui5-cc-spreadsheetimporter/src/i18n/i18n_pt.properties
@@ -12,6 +12,16 @@ spreadsheetimporter.showPreview=Mostrar pré-visualização
 spreadsheetimporter.dataRows=<strong>{0}</strong> registros prontos para upload
 spreadsheetimporter.showOptionMenu=Mostrar opções
 spreadsheetimporter.dropMessage=Solte o arquivo aqui
+spreadsheetimporter.downloadDataSpreadsheet=Baixar Dados como Planilha
+
+# Spreadsheet Download Option Dialog
+spreadsheetimporter.spreadsheetDownloadOptionsDialogTitle=Opções de Download de Planilha
+spreadsheetimporter.spreadsheetDownloadDialogFilename=Nome do arquivo
+spreadsheetimporter.spreadsheetDownloadDialogForeignKeys=Adicionar Chaves
+spreadsheetimporter.spreadsheetDownloadDialogDeepExport=Exportação Profunda
+spreadsheetimporter.spreadsheetDownloadDialogDeepLevel=Níveis para Exportação Profunda
+spreadsheetimporter.startDownloadingSpreadsheet=Baixar Planilha
+spreadsheetimporter.closeSpreadsheetDownloadDialog=Cancelar
 
 # Spreadsheet Upload Dialog - Class
 spreadsheetimporter.selectFileUpload=Selecionar arquivo para upload

--- a/packages/ui5-cc-spreadsheetimporter/src/i18n/i18n_zh.properties
+++ b/packages/ui5-cc-spreadsheetimporter/src/i18n/i18n_zh.properties
@@ -12,6 +12,16 @@ spreadsheetimporter.showPreview=显示预览
 spreadsheetimporter.dataRows=<strong>{0}</strong> 条记录已准备好上传
 spreadsheetimporter.showOptionMenu=显示选项
 spreadsheetimporter.dropMessage=将文件拖到这里
+spreadsheetimporter.downloadDataSpreadsheet=将数据下载为电子表格
+
+# Spreadsheet Download Option Dialog
+spreadsheetimporter.spreadsheetDownloadOptionsDialogTitle=电子表格下载选项
+spreadsheetimporter.spreadsheetDownloadDialogFilename=文件名
+spreadsheetimporter.spreadsheetDownloadDialogForeignKeys=添加键
+spreadsheetimporter.spreadsheetDownloadDialogDeepExport=深度导出
+spreadsheetimporter.spreadsheetDownloadDialogDeepLevel=深度导出的层次
+spreadsheetimporter.startDownloadingSpreadsheet=下载电子表格
+spreadsheetimporter.closeSpreadsheetDownloadDialog=取消
 
 # Spreadsheet Upload Dialog - Class
 spreadsheetimporter.selectFileUpload=选择要上传的文件

--- a/packages/ui5-cc-spreadsheetimporter/src/types.d.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/types.d.ts
@@ -125,7 +125,6 @@ export interface DeepDownloadConfig {
 	deepLevel: number;
 	showOptions: boolean;
 	columns: any;
-	flatSheet?: boolean;
 	filename?: string;
 }
 

--- a/packages/ui5-cc-spreadsheetimporter/src/types.d.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/types.d.ts
@@ -12,6 +12,7 @@ export interface Property {
 	type: string;
 	label: string;
 	precision?: number;
+	$XYZKey?: boolean;
 }
 export type ListObject = Map<string, Property>;
 export type PropertyArray = { [key: string]: any }[];
@@ -114,6 +115,7 @@ export interface ComponentData {
 	createActiveEntity?: boolean;
 	i18nModel?: object;
 	bindingCustom?: object;
+	showDownloadButton?: boolean;
 	deepDownloadConfig?: DeepDownloadConfig;
 }
 

--- a/packages/ui5-cc-spreadsheetimporter/src/types.d.ts
+++ b/packages/ui5-cc-spreadsheetimporter/src/types.d.ts
@@ -114,6 +114,17 @@ export interface ComponentData {
 	createActiveEntity?: boolean;
 	i18nModel?: object;
 	bindingCustom?: object;
+	deepDownloadConfig?: DeepDownloadConfig;
+}
+
+export interface DeepDownloadConfig {
+	addKeysToExport: boolean;
+	deepExport: boolean;
+	deepLevel: number;
+	showOptions: boolean;
+	columns: any;
+	flatSheet?: boolean;
+	filename?: string;
 }
 
 export type FireEventReturnType = {
@@ -121,5 +132,30 @@ export type FireEventReturnType = {
 	mParameters: object;
 	returnValue: object;
 };
+
+export type ListObject = Map<string, Property>;
+
+export type PropertyObject = {
+	propertyName: string;
+	propertyValue: any; // Replace 'any' with a more specific type if possible.
+	propertyLabel: [x: string];
+};
+
+interface EntityDefinition {
+	$kind: string;
+	$Key?: string[];
+	[key: string]: PropertyDefinition | NavigationPropertyDefinition | any;
+};
+
+type EntityObject = {
+	$kind: string;
+	$Type?: string;
+	$NavigationPropertyBinding?: Record<string, string>;
+};
+
+interface PropertyWithOrder {
+	name: string;
+	order: number;
+}
 
 // Pro Types

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -939,6 +939,28 @@ importers:
         specifier: 3.3.1
         version: 3.3.1
 
+  examples/packages/ordersv4freestyle:
+    dependencies:
+      ui5-cc-spreadsheetimporter:
+        specifier: link:../../../packages/ui5-cc-spreadsheetimporter
+        version: link:../../../packages/ui5-cc-spreadsheetimporter
+    devDependencies:
+      '@sap-ux/ui5-middleware-fe-mockserver':
+        specifier: '2'
+        version: 2.2.76
+      '@sap/ux-ui5-tooling':
+        specifier: '1'
+        version: 1.15.3(encoding@0.1.13)
+      '@ui5/cli':
+        specifier: ^3.0.0
+        version: 3.11.5(bluebird@3.7.2)
+      ui5-middleware-ui5:
+        specifier: 3.2.1
+        version: 3.2.1(@ui5/fs@4.0.1)(@ui5/project@4.0.3(@ui5/builder@4.0.3)(bluebird@3.7.2))(@ui5/server@4.0.5)
+      ui5-tooling-modules:
+        specifier: 3.18.0
+        version: 3.18.0(@ui5/project@4.0.3(@ui5/builder@4.0.3)(bluebird@3.7.2))(typescript@5.6.3)
+
   examples/packages/server:
     dependencies:
       '@cap-js-community/odata-v2-adapter':
@@ -2690,6 +2712,10 @@ packages:
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
+  '@sindresorhus/is@5.6.0':
+    resolution: {integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==}
+    engines: {node: '>=14.16'}
+
   '@sindresorhus/merge-streams@2.3.0':
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
@@ -2697,6 +2723,10 @@ packages:
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
+
+  '@szmarczak/http-timer@5.0.1':
+    resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
+    engines: {node: '>=14.16'}
 
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
@@ -2726,6 +2756,9 @@ packages:
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
+
+  '@types/http-cache-semantics@4.0.4':
+    resolution: {integrity: sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==}
 
   '@types/http-proxy@1.17.15':
     resolution: {integrity: sha512-25g5atgiVNTIv0LBDTg1H74Hvayx0ajtJPLLcYE3whFv75J0pWNtOBzaXJQgDTmrX1bx5U9YC2w/n65BN1HwRQ==}
@@ -2894,9 +2927,18 @@ packages:
     resolution: {integrity: sha512-vG0XZo8AdTH9OE6VFRwAZldNc7qtJ/6NLGWak+BtENuEUXGZgFpihILPiBvKXvJ2nFu27XNGC6rKiwuaoMbYzQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@ui5/builder@3.5.1':
+    resolution: {integrity: sha512-RpiWIarR876+CILtbzCM0hAjMA0oYkS6N/UIocnwPIOKCfZKrDJnpBoAnzgyq/fOF+jm9XXhSnJrkXnyvPPysw==}
+    engines: {node: ^16.18.0 || >=18.12.0, npm: '>= 8'}
+
   '@ui5/builder@4.0.3':
     resolution: {integrity: sha512-05CkKaR48ZXQYN7LZuVtJ/cpm1PJCFogB697PBigHsFTmE/TuB/g5p5q/G7zNuitiF3GB3fp6xp0BjcYr5YSNg==}
     engines: {node: ^20.11.0 || >=22.0.0, npm: '>= 8'}
+
+  '@ui5/cli@3.11.5':
+    resolution: {integrity: sha512-FoV8k943sPfz895ImVOULDp/CUjGAxhUPX6iPzF/9vItKTKCopelwSk6NMt2kfErSTjEUjajLe1mh2bhhJRHcg==}
+    engines: {node: ^16.18.0 || >=18.12.0, npm: '>= 8'}
+    hasBin: true
 
   '@ui5/cli@4.0.9':
     resolution: {integrity: sha512-WTMa21zyXlby6mYUxylVXpL71P7EsVAQknjRplIa9t5GgiPXk2okZf8tVyts3UohPXC2eelf7aBxG+8Fbc2UHA==}
@@ -2905,6 +2947,10 @@ packages:
 
   '@ui5/fs@3.0.4':
     resolution: {integrity: sha512-0JnlsSvqOGlo+15+mP1E2HXOuRERBYWREVG45emDMRq7fNAsi7lgbKHTMA5GogJMRHI8/QaCV9vU1u370Bv1jg==}
+    engines: {node: ^16.18.0 || >=18.12.0, npm: '>= 8'}
+
+  '@ui5/fs@3.0.5':
+    resolution: {integrity: sha512-SpDoMvOGYeBR8xOTDb1cu0uxJNsC1FxrENsZiRMd6R2PfUAiR0fiWQHn4dVBspoLx+jFemAfLfTMv1DEn0m1qQ==}
     engines: {node: ^16.18.0 || >=18.12.0, npm: '>= 8'}
 
   '@ui5/fs@4.0.1':
@@ -2929,6 +2975,10 @@ packages:
     resolution: {integrity: sha512-M6ftnWiUXq3SVLLQ5XTBoJNdxzDvu71FoGh4iIR2kpaDCgpQ5DbHuBRhKAlrUB6EmIFzOxKepgYN95z09xbCbA==}
     engines: {node: ^20.11.0 || >=22.0.0, npm: '>= 8'}
 
+  '@ui5/project@3.9.2':
+    resolution: {integrity: sha512-IkpDXWWiTE7eZibcQoWi09zbXAn+FJJN3boXNpZBVUxzqiqZRVatRLWdKD4TvyLZ7FvAikkufGkl+z/h2r20cQ==}
+    engines: {node: ^16.18.0 || >=18.12.0, npm: '>= 8'}
+
   '@ui5/project@4.0.3':
     resolution: {integrity: sha512-6APsQ2iicR3A8ZBZyr+tKaod5kZCBVPWEBEV8fnzZ2DhXd73Z1KSeyVFPtm3cHgf/0vW9I9+EwIyNBtK5zAGWw==}
     engines: {node: ^20.11.0 || >=22.0.0, npm: '>= 8'}
@@ -2937,6 +2987,10 @@ packages:
     peerDependenciesMeta:
       '@ui5/builder':
         optional: true
+
+  '@ui5/server@3.3.0':
+    resolution: {integrity: sha512-AsqYgr3rTXwsnoaSX3tm78QeiKoKSOMDKR/s60lyTmANIuheECDK9JBLv6NIzp6chCp8Cbbdp/mMScnVlLy7QA==}
+    engines: {node: ^16.18.0 || >=18.12.0, npm: '>= 8'}
 
   '@ui5/server@4.0.5':
     resolution: {integrity: sha512-hbe2fXylNi3M5DP7VKvac8vWEDm15PT1pQ++hTXM8UnLqEIDja9fkYTgpCqzIFqrFgoXk8bMOo8eJ0h/Z4mvsg==}
@@ -3325,6 +3379,10 @@ packages:
   better-sqlite3@11.5.0:
     resolution: {integrity: sha512-e/6eggfOutzoK0JWiU36jsisdWoHOfN9iWiW/SieKvb7SAa6aGNmBM/UKyp+/wWSXpLlWNN8tCPwoDNPhzUvuQ==}
 
+  big-integer@1.6.52:
+    resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
+    engines: {node: '>=0.6'}
+
   big.js@6.2.2:
     resolution: {integrity: sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==}
 
@@ -3363,9 +3421,17 @@ packages:
     resolution: {integrity: sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==}
     engines: {node: '>=10'}
 
+  boxen@7.1.1:
+    resolution: {integrity: sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==}
+    engines: {node: '>=14.16'}
+
   boxen@8.0.1:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
     engines: {node: '>=18'}
+
+  bplist-parser@0.2.0:
+    resolution: {integrity: sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==}
+    engines: {node: '>= 5.10.0'}
 
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -3408,6 +3474,10 @@ packages:
   builtins@5.1.0:
     resolution: {integrity: sha512-SW9lzGTLvWTP1AY8xeAMZimqDrIaSdLQUcVr9DMef51niJ022Ri87SwRRKYm4A6iHfkPaiVUu/Duw2Wc4J7kKg==}
 
+  bundle-name@3.0.0:
+    resolution: {integrity: sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==}
+    engines: {node: '>=12'}
+
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
@@ -3424,6 +3494,14 @@ packages:
     resolution: {integrity: sha512-B+L5iIa9mgcjLbliir2th36yEwPftrzteHYujzsx3dFP/31GCHcIeS8f5MGd80odLOjaOvSpU3EEAmRQptkxLQ==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
+  cacheable-lookup@7.0.0:
+    resolution: {integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==}
+    engines: {node: '>=14.16'}
+
+  cacheable-request@10.2.14:
+    resolution: {integrity: sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==}
+    engines: {node: '>=14.16'}
+
   call-bind@1.0.7:
     resolution: {integrity: sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==}
     engines: {node: '>= 0.4'}
@@ -3435,6 +3513,10 @@ packages:
   camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
+
+  camelcase@7.0.1:
+    resolution: {integrity: sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==}
+    engines: {node: '>=14.16'}
 
   camelcase@8.0.0:
     resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
@@ -3488,6 +3570,10 @@ packages:
   cheerio@1.0.0:
     resolution: {integrity: sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==}
     engines: {node: '>=18.17'}
+
+  cheerio@1.0.0-rc.12:
+    resolution: {integrity: sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==}
+    engines: {node: '>= 6'}
 
   chevrotain@7.1.1:
     resolution: {integrity: sha512-wy3mC1x4ye+O+QkEinVJkPf5u2vsrDIYW9G7ZuwFl6v/Yu0LwUuT2POsb+NUWApebyxfkQq6+yDfRExbnI5rcw==}
@@ -3687,6 +3773,10 @@ packages:
     resolution: {integrity: sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==}
     engines: {node: '>=8'}
 
+  configstore@6.0.0:
+    resolution: {integrity: sha512-cD31W1v3GqUlQvbBCGcXmd2Nj9SvLDOP1oQ0YFuLETufzSPaKp11rYBsSOm7rCsW3OnIRAFM3OxRhceaXNYHkA==}
+    engines: {node: '>=12'}
+
   configstore@7.0.0:
     resolution: {integrity: sha512-yk7/5PN5im4qwz0WFZW3PXnzHgPu9mX29Y8uZ3aefe2lBPC1FYttWZRcaW9fKkT0pBCJyuQ2HfbmPVaODi9jcQ==}
     engines: {node: '>=18'}
@@ -3787,6 +3877,10 @@ packages:
   crypto-random-string@2.0.0:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
     engines: {node: '>=8'}
+
+  crypto-random-string@4.0.0:
+    resolution: {integrity: sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==}
+    engines: {node: '>=12'}
 
   css-select@5.1.0:
     resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
@@ -3907,9 +4001,17 @@ packages:
     resolution: {integrity: sha512-qCSH6I0INPxd9Y1VtAiLpnYvz5O//6rCfJXKk0z66Up9/VOSr+1yS8XSKA5IWRxjocFGlzPyaZYe+jxq7OOLtQ==}
     engines: {node: '>=16.0.0'}
 
+  default-browser-id@3.0.0:
+    resolution: {integrity: sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==}
+    engines: {node: '>=12'}
+
   default-browser-id@5.0.0:
     resolution: {integrity: sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==}
     engines: {node: '>=18'}
+
+  default-browser@4.0.0:
+    resolution: {integrity: sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==}
+    engines: {node: '>=14.16'}
 
   default-browser@5.2.1:
     resolution: {integrity: sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==}
@@ -3917,6 +4019,10 @@ packages:
 
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
+
+  defer-to-connect@2.0.1:
+    resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
+    engines: {node: '>=10'}
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -3958,6 +4064,9 @@ packages:
 
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
+
+  devcert-sanscache@0.4.8:
+    resolution: {integrity: sha512-AcuD5yTpKdY5VnZdADR2wIZMOaEqNQnIEIxuvSzu7iAWLh/I/g3Bhm6FebUby1tfd6RGtPwN5/Gp0nNT67ZSRQ==}
 
   devcert-sanscache@0.5.1:
     resolution: {integrity: sha512-9ePmMvWItstun0c35V5WXUlNU4MCHtpXWxKUJcDiZvyKkcA3FxkL6PFHKqTd446mXMmvLpOGBxVD6GjBXeMA5A==}
@@ -4013,6 +4122,10 @@ packages:
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
+
+  dot-prop@6.0.1:
+    resolution: {integrity: sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==}
+    engines: {node: '>=10'}
 
   dot-prop@9.0.0:
     resolution: {integrity: sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==}
@@ -4210,6 +4323,10 @@ packages:
     resolution: {integrity: sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  espree@9.6.1:
+    resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
@@ -4262,6 +4379,10 @@ packages:
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
+
+  execa@7.2.0:
+    resolution: {integrity: sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==}
+    engines: {node: ^14.18.0 || ^16.14.0 || >=18.0.0}
 
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
@@ -4456,6 +4577,10 @@ packages:
   form-data-encoder@1.7.2:
     resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
 
+  form-data-encoder@2.1.4:
+    resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
+    engines: {node: '>= 14.17'}
+
   form-data@4.0.1:
     resolution: {integrity: sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==}
     engines: {node: '>= 6'}
@@ -4545,6 +4670,10 @@ packages:
   get-intrinsic@1.2.4:
     resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
     engines: {node: '>= 0.4'}
+
+  get-port@3.2.0:
+    resolution: {integrity: sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg==}
+    engines: {node: '>=4'}
 
   get-port@6.1.2:
     resolution: {integrity: sha512-BrGGraKm2uPqurfGVj/z97/zv8dPleC6x9JBNRTrDNtCkkRF4rPwrQXFgL7+I+q8QSdU4ntLQX2D7KIxSy8nGw==}
@@ -4660,6 +4789,10 @@ packages:
   gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
 
+  got@12.6.1:
+    resolution: {integrity: sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==}
+    engines: {node: '>=14.16'}
+
   graceful-fs@4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
 
@@ -4717,6 +4850,10 @@ packages:
     resolution: {integrity: sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==}
     engines: {node: '>=8'}
 
+  has-yarn@3.0.0:
+    resolution: {integrity: sha512-IrsVwUHhEULx3R8f/aA8AHuEzAorplsab/v8HBzEiIukwq5i/EC+xmOW+HfP1OaDP+2JkgT1yILHN2O3UFIbcA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
@@ -4745,6 +4882,9 @@ packages:
 
   htmlfy@0.3.2:
     resolution: {integrity: sha512-FsxzfpeDYRqn1emox9VpxMPfGjADoUmmup8D604q497R0VNxiXs4ZZTN2QzkaMA5C9aHGUoe1iQRVSm+HK9xuA==}
+
+  htmlparser2@8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
   htmlparser2@9.1.0:
     resolution: {integrity: sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==}
@@ -4780,6 +4920,10 @@ packages:
     resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
     engines: {node: '>=8.0.0'}
 
+  http2-wrapper@2.2.1:
+    resolution: {integrity: sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==}
+    engines: {node: '>=10.19.0'}
+
   https-proxy-agent@7.0.5:
     resolution: {integrity: sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==}
     engines: {node: '>= 14'}
@@ -4787,6 +4931,10 @@ packages:
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+
+  human-signals@4.3.1:
+    resolution: {integrity: sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==}
+    engines: {node: '>=14.18.0'}
 
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
@@ -4859,6 +5007,10 @@ packages:
   import-lazy@2.1.0:
     resolution: {integrity: sha512-m7ZEHgtw69qOGw+jwxXkHlrlIPdTGkyh66zXZ1ajZbxkDBNjSY/LGbmjc7h0s2ELsUDTAhFr55TrPSSqJGPG0A==}
     engines: {node: '>=4'}
+
+  import-lazy@4.0.0:
+    resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
+    engines: {node: '>=8'}
 
   import-local@3.2.0:
     resolution: {integrity: sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==}
@@ -4957,6 +5109,10 @@ packages:
 
   is-ci@2.0.0:
     resolution: {integrity: sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==}
+    hasBin: true
+
+  is-ci@3.0.1:
+    resolution: {integrity: sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==}
     hasBin: true
 
   is-core-module@2.15.1:
@@ -5161,6 +5317,10 @@ packages:
   is-yarn-global@0.3.0:
     resolution: {integrity: sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==}
 
+  is-yarn-global@0.4.1:
+    resolution: {integrity: sha512-/kppl+R+LO5VmhYSEWARUFjodS25D68gvj8W7z0I7OWhUla5xWu8KL6CtB2V0R6yqhnRgbcaREMr4EEM6htLPQ==}
+    engines: {node: '>=12'}
+
   is2@2.0.9:
     resolution: {integrity: sha512-rZkHeBn9Zzq52sd9IUIV3a5mfwBY+o2HePMh0wkGBM4z4qjvy2GwVxQ6nNXSfw6MmVP6gf1QIlWjiOavhM3x5g==}
     engines: {node: '>=v0.10.0'}
@@ -5315,6 +5475,10 @@ packages:
   ky@1.7.2:
     resolution: {integrity: sha512-OzIvbHKKDpi60TnF9t7UUVAF1B4mcqc02z5PIvrm08Wyb+yOcz63GRvEuVxNT18a9E1SrNouhB4W2NNLeD7Ykg==}
     engines: {node: '>=18'}
+
+  latest-version@7.0.0:
+    resolution: {integrity: sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==}
+    engines: {node: '>=14.16'}
 
   latest-version@9.0.0:
     resolution: {integrity: sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA==}
@@ -5485,6 +5649,10 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lowercase-keys@3.0.0:
+    resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -5617,6 +5785,10 @@ packages:
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
+
+  mimic-response@4.0.0:
+    resolution: {integrity: sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   min-document@2.19.0:
     resolution: {integrity: sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==}
@@ -5817,6 +5989,10 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  normalize-url@8.0.1:
+    resolution: {integrity: sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==}
+    engines: {node: '>=14.16'}
+
   npm-bundled@3.0.1:
     resolution: {integrity: sha512-+AvaheE/ww1JEwRHOrn4WHNzOxGtVp+adrg2AeZS/7KuxGUYFuBta98wYpfHBbJp6Tg6j1NKSEVHNcfZzJHQwQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -5933,6 +6109,10 @@ packages:
     resolution: {integrity: sha512-sP2ru2v0P290WFfv49Ap8MF6PkzGNnGlAwHweB4WR4mr5d2d0woiCluUeJ218w7/+PmoBy9JmYgD5A4mLcWOFA==}
     engines: {node: '>=8'}
 
+  open@9.1.0:
+    resolution: {integrity: sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==}
+    engines: {node: '>=14.16'}
+
   openai@4.70.2:
     resolution: {integrity: sha512-Q2ymi/KPUYv+LJ9rFxeYxpkVAhcrZFTVvnJbdF1pUHg9eMC6lY8PU4TO1XOK5UZzOZuuVicouRwVMi1iDrT4qw==}
     hasBin: true
@@ -5960,6 +6140,10 @@ packages:
   os-tmpdir@1.0.2:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
+
+  p-cancelable@3.0.0:
+    resolution: {integrity: sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==}
+    engines: {node: '>=12.20'}
 
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
@@ -6007,6 +6191,10 @@ packages:
   package-json@10.0.1:
     resolution: {integrity: sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==}
     engines: {node: '>=18'}
+
+  package-json@8.1.1:
+    resolution: {integrity: sha512-cbH9IAIJHNj9uXi196JVsRlt7cHKak6u/e6AkL/bkRelZ7rlL3X1YKxsZwa36xipOEKAsdtmaG6aAJoM1fx2zA==}
+    engines: {node: '>=14.16'}
 
   pacote@18.0.6:
     resolution: {integrity: sha512-+eK3G27SMwsB8kLIuj4h1FUhHtwiEUo21Tw8wNjmvdlpOEr613edv+8FUsTj/4F/VN5ywGE19X18N7CC2EJk6A==}
@@ -6356,6 +6544,10 @@ packages:
   queue-tick@1.0.1:
     resolution: {integrity: sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==}
 
+  quick-lru@5.1.1:
+    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
+    engines: {node: '>=10'}
+
   random-int@3.0.0:
     resolution: {integrity: sha512-QvewnOwigesW2WFyTHiQzR6XUUcSQO/BqmfgRz5N5GpGrKQnTf7ebMz8UtuwaET8IfO1n0wLx8/fHsI8E0Jpow==}
     engines: {node: '>=12'}
@@ -6535,6 +6727,9 @@ packages:
     engines: {node: '>=12.22.12'}
     hasBin: true
 
+  resolve-alpn@1.2.1:
+    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
+
   resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
     engines: {node: '>=8'}
@@ -6553,6 +6748,10 @@ packages:
   resolve@1.22.8:
     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
     hasBin: true
+
+  responselike@3.0.0:
+    resolution: {integrity: sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==}
+    engines: {node: '>=14.16'}
 
   resq@1.11.0:
     resolution: {integrity: sha512-G10EBz+zAAy3zUd/CDoBbXRL6ia9kOo3xRHrMDsHljI0GDkhYlyjwoCx5+3eCC4swi1uCoZQhskuJkj7Gp57Bw==}
@@ -6579,6 +6778,11 @@ packages:
   rgb2hex@0.2.5:
     resolution: {integrity: sha512-22MOP1Rh7sAo1BZpDG6R5RFYzR2lYEgwq7HEmyW2qcsOqR2lQKmn+O//xV3YG/0rrhMC6KVX2hU+ZXuaw9a5bw==}
 
+  rimraf@2.7.1:
+    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
   rimraf@5.0.10:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
@@ -6601,6 +6805,10 @@ packages:
   router@2.0.0:
     resolution: {integrity: sha512-dIM5zVoG8xhC6rnSN8uoAgFARwTE7BQs8YwHEvK0VCmfxQXMaOuA1uiR1IPwsW7JyK5iTt7Od/TC9StasS2NPQ==}
     engines: {node: '>= 0.10'}
+
+  run-applescript@5.0.0:
+    resolution: {integrity: sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==}
+    engines: {node: '>=12'}
 
   run-applescript@7.0.0:
     resolution: {integrity: sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==}
@@ -6662,6 +6870,10 @@ packages:
   semver-diff@3.1.1:
     resolution: {integrity: sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==}
     engines: {node: '>=8'}
+
+  semver-diff@4.0.0:
+    resolution: {integrity: sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==}
+    engines: {node: '>=12'}
 
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
@@ -7045,6 +7257,10 @@ packages:
     resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
     engines: {node: '>=14.0.0'}
 
+  titleize@3.0.0:
+    resolution: {integrity: sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==}
+    engines: {node: '>=12'}
+
   tmp@0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
     engines: {node: '>=0.6.0'}
@@ -7116,6 +7332,10 @@ packages:
 
   type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
+
+  type-fest@1.4.0:
+    resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
     engines: {node: '>=10'}
 
   type-fest@2.19.0:
@@ -7274,6 +7494,10 @@ packages:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
     engines: {node: '>=8'}
 
+  unique-string@3.0.0:
+    resolution: {integrity: sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==}
+    engines: {node: '>=12'}
+
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
@@ -7286,6 +7510,10 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
+  untildify@4.0.0:
+    resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}
+    engines: {node: '>=8'}
+
   update-browserslist-db@1.1.1:
     resolution: {integrity: sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==}
     hasBin: true
@@ -7295,6 +7523,10 @@ packages:
   update-notifier-cjs@5.1.6:
     resolution: {integrity: sha512-wgxdSBWv3x/YpMzsWz5G4p4ec7JWD0HCl8W6bmNB6E5Gwo+1ym5oN4hiXpLf0mPySVEJEIsYlkshnplkg2OP9A==}
     engines: {node: '>=14'}
+
+  update-notifier@6.0.2:
+    resolution: {integrity: sha512-EDxhTEVPZZRLWYcJ4ZXjGFN0oP7qYvbXWzEgRm/Yql4dHX5wDbvh89YHP6PK1lzZJYrMtXUuZZz8XGK+U6U1og==}
+    engines: {node: '>=14.16'}
 
   update-notifier@7.3.1:
     resolution: {integrity: sha512-+dwUY4L35XFYEzE+OAL3sarJdUioVovq+8f7lcIJ7wnmnYQV5UD1Y/lcwaMSyaQ6Bj3JMj1XSTjZbNLHn/19yA==}
@@ -7478,6 +7710,10 @@ packages:
   widest-line@3.1.0:
     resolution: {integrity: sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==}
     engines: {node: '>=8'}
+
+  widest-line@4.0.1:
+    resolution: {integrity: sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==}
+    engines: {node: '>=12'}
 
   widest-line@5.0.0:
     resolution: {integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==}
@@ -9865,9 +10101,15 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
+  '@sindresorhus/is@5.6.0': {}
+
   '@sindresorhus/merge-streams@2.3.0': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@szmarczak/http-timer@5.0.1':
+    dependencies:
+      defer-to-connect: 2.0.1
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
@@ -9891,6 +10133,8 @@ snapshots:
       '@types/node': 22.8.7
 
   '@types/estree@1.0.6': {}
+
+  '@types/http-cache-semantics@4.0.4': {}
 
   '@types/http-proxy@1.17.15':
     dependencies:
@@ -10086,6 +10330,25 @@ snapshots:
       '@typescript-eslint/types': 8.14.0
       eslint-visitor-keys: 3.4.3
 
+  '@ui5/builder@3.5.1':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
+      '@ui5/fs': 3.0.5
+      '@ui5/logger': 3.0.0
+      cheerio: 1.0.0-rc.12
+      escape-unicode: 0.2.0
+      escope: 4.0.0
+      espree: 9.6.1
+      graceful-fs: 4.2.11
+      jsdoc: 4.0.4
+      less-openui5: 0.11.6
+      pretty-data: 0.40.0
+      rimraf: 5.0.10
+      semver: 7.6.3
+      terser: 5.36.0
+      workerpool: 6.5.1
+      xml2js: 0.6.2
+
   '@ui5/builder@4.0.3':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -10104,6 +10367,26 @@ snapshots:
       terser: 5.36.0
       workerpool: 9.2.0
       xml2js: 0.6.2
+
+  '@ui5/cli@3.11.5(bluebird@3.7.2)':
+    dependencies:
+      '@ui5/builder': 3.5.1
+      '@ui5/fs': 3.0.5
+      '@ui5/logger': 3.0.0
+      '@ui5/project': 3.9.2(bluebird@3.7.2)
+      '@ui5/server': 3.3.0
+      chalk: 5.3.0
+      data-with-position: 0.5.0
+      import-local: 3.2.0
+      js-yaml: 4.1.0
+      open: 9.1.0
+      pretty-hrtime: 1.0.3
+      semver: 7.6.3
+      update-notifier: 6.0.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
 
   '@ui5/cli@4.0.9(bluebird@3.7.2)':
     dependencies:
@@ -10126,6 +10409,18 @@ snapshots:
       - supports-color
 
   '@ui5/fs@3.0.4':
+    dependencies:
+      '@ui5/logger': 3.0.0
+      clone: 2.1.2
+      escape-string-regexp: 5.0.0
+      globby: 13.2.2
+      graceful-fs: 4.2.11
+      micromatch: 4.0.8
+      minimatch: 9.0.5
+      pretty-hrtime: 1.0.3
+      random-int: 3.0.0
+
+  '@ui5/fs@3.0.5':
     dependencies:
       '@ui5/logger': 3.0.0
       clone: 2.1.2
@@ -10188,6 +10483,35 @@ snapshots:
       cli-progress: 3.12.0
       figures: 6.1.0
 
+  '@ui5/project@3.9.2(bluebird@3.7.2)':
+    dependencies:
+      '@npmcli/config': 8.3.4(bluebird@3.7.2)
+      '@ui5/builder': 3.5.1
+      '@ui5/fs': 3.0.5
+      '@ui5/logger': 3.0.0
+      ajv: 6.12.6
+      ajv-errors: 1.0.1(ajv@6.12.6)
+      chalk: 5.3.0
+      escape-string-regexp: 5.0.0
+      globby: 13.2.2
+      graceful-fs: 4.2.11
+      js-yaml: 4.1.0
+      lockfile: 1.0.4
+      make-fetch-happen: 13.0.1
+      node-stream-zip: 1.15.0
+      pacote: 18.0.6(bluebird@3.7.2)
+      pretty-hrtime: 1.0.3
+      read-pkg: 8.1.0
+      read-pkg-up: 10.1.0
+      resolve: 1.22.8
+      rimraf: 5.0.10
+      semver: 7.6.3
+      xml2js: 0.6.2
+      yesno: 0.4.0
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+
   '@ui5/project@4.0.3(@ui5/builder@4.0.3)(bluebird@3.7.2)':
     dependencies:
       '@npmcli/config': 8.3.4(bluebird@3.7.2)
@@ -10216,6 +10540,30 @@ snapshots:
       '@ui5/builder': 4.0.3
     transitivePeerDependencies:
       - bluebird
+      - supports-color
+
+  '@ui5/server@3.3.0':
+    dependencies:
+      '@ui5/builder': 3.5.1
+      '@ui5/fs': 3.0.5
+      '@ui5/logger': 3.0.0
+      body-parser: 1.20.3
+      compression: 1.7.5
+      cors: 2.8.5
+      devcert-sanscache: 0.4.8
+      escape-html: 1.0.3
+      etag: 1.8.1
+      express: 4.21.1
+      fresh: 0.5.2
+      graceful-fs: 4.2.11
+      mime-types: 2.1.35
+      parseurl: 1.3.3
+      portscanner: 2.2.0
+      replacestream: 4.0.3
+      router: 2.0.0
+      spdy: 4.0.2
+      yesno: 0.4.0
+    transitivePeerDependencies:
       - supports-color
 
   '@ui5/server@4.0.5':
@@ -10782,6 +11130,8 @@ snapshots:
       bindings: 1.5.0
       prebuild-install: 7.1.2
 
+  big-integer@1.6.52: {}
+
   big.js@6.2.2: {}
 
   binary-extensions@2.3.0: {}
@@ -10836,6 +11186,17 @@ snapshots:
       widest-line: 3.1.0
       wrap-ansi: 7.0.0
 
+  boxen@7.1.1:
+    dependencies:
+      ansi-align: 3.0.1
+      camelcase: 7.0.1
+      chalk: 5.3.0
+      cli-boxes: 3.0.0
+      string-width: 5.1.2
+      type-fest: 2.19.0
+      widest-line: 4.0.1
+      wrap-ansi: 8.1.0
+
   boxen@8.0.1:
     dependencies:
       ansi-align: 3.0.1
@@ -10846,6 +11207,10 @@ snapshots:
       type-fest: 4.26.1
       widest-line: 5.0.0
       wrap-ansi: 9.0.0
+
+  bplist-parser@0.2.0:
+    dependencies:
+      big-integer: 1.6.52
 
   brace-expansion@1.1.11:
     dependencies:
@@ -10891,6 +11256,10 @@ snapshots:
     dependencies:
       semver: 7.6.3
 
+  bundle-name@3.0.0:
+    dependencies:
+      run-applescript: 5.0.0
+
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.0.0
@@ -10916,6 +11285,18 @@ snapshots:
       tar: 6.2.1
       unique-filename: 3.0.0
 
+  cacheable-lookup@7.0.0: {}
+
+  cacheable-request@10.2.14:
+    dependencies:
+      '@types/http-cache-semantics': 4.0.4
+      get-stream: 6.0.1
+      http-cache-semantics: 4.1.1
+      keyv: 4.5.4
+      mimic-response: 4.0.0
+      normalize-url: 8.0.1
+      responselike: 3.0.0
+
   call-bind@1.0.7:
     dependencies:
       es-define-property: 1.0.0
@@ -10927,6 +11308,8 @@ snapshots:
   callsites@3.1.0: {}
 
   camelcase@6.3.0: {}
+
+  camelcase@7.0.1: {}
 
   camelcase@8.0.0: {}
 
@@ -11006,6 +11389,16 @@ snapshots:
       parse5-parser-stream: 7.1.2
       undici: 6.20.1
       whatwg-mimetype: 4.0.0
+
+  cheerio@1.0.0-rc.12:
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      htmlparser2: 8.0.2
+      parse5: 7.2.1
+      parse5-htmlparser2-tree-adapter: 7.1.0
 
   chevrotain@7.1.1:
     dependencies:
@@ -11223,6 +11616,14 @@ snapshots:
       write-file-atomic: 3.0.3
       xdg-basedir: 4.0.0
 
+  configstore@6.0.0:
+    dependencies:
+      dot-prop: 6.0.1
+      graceful-fs: 4.2.11
+      unique-string: 3.0.0
+      write-file-atomic: 3.0.3
+      xdg-basedir: 5.1.0
+
   configstore@7.0.0:
     dependencies:
       atomically: 2.0.3
@@ -11323,6 +11724,10 @@ snapshots:
 
   crypto-random-string@2.0.0: {}
 
+  crypto-random-string@4.0.0:
+    dependencies:
+      type-fest: 1.4.0
+
   css-select@5.1.0:
     dependencies:
       boolbase: 1.0.0
@@ -11409,7 +11814,19 @@ snapshots:
 
   deepmerge-ts@7.1.3: {}
 
+  default-browser-id@3.0.0:
+    dependencies:
+      bplist-parser: 0.2.0
+      untildify: 4.0.0
+
   default-browser-id@5.0.0: {}
+
+  default-browser@4.0.0:
+    dependencies:
+      bundle-name: 3.0.0
+      default-browser-id: 3.0.0
+      execa: 7.2.0
+      titleize: 3.0.0
 
   default-browser@5.2.1:
     dependencies:
@@ -11419,6 +11836,8 @@ snapshots:
   defaults@1.0.4:
     dependencies:
       clone: 1.0.4
+
+  defer-to-connect@2.0.1: {}
 
   define-data-property@1.1.4:
     dependencies:
@@ -11453,6 +11872,14 @@ snapshots:
   detect-libc@2.0.3: {}
 
   detect-node@2.1.0: {}
+
+  devcert-sanscache@0.4.8:
+    dependencies:
+      command-exists: 1.2.9
+      get-port: 3.2.0
+      glob: 7.2.3
+      mkdirp: 0.5.6
+      rimraf: 2.7.1
 
   devcert-sanscache@0.5.1:
     dependencies:
@@ -11522,6 +11949,10 @@ snapshots:
       domhandler: 5.0.3
 
   dot-prop@5.3.0:
+    dependencies:
+      is-obj: 2.0.0
+
+  dot-prop@6.0.1:
     dependencies:
       is-obj: 2.0.0
 
@@ -11805,6 +12236,12 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.14.0)
       eslint-visitor-keys: 4.2.0
 
+  espree@9.6.1:
+    dependencies:
+      acorn: 8.14.0
+      acorn-jsx: 5.3.2(acorn@8.14.0)
+      eslint-visitor-keys: 3.4.3
+
   esprima@4.0.1: {}
 
   esquery@1.6.0:
@@ -11848,6 +12285,18 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
+
+  execa@7.2.0:
+    dependencies:
+      cross-spawn: 7.0.5
+      get-stream: 6.0.1
+      human-signals: 4.3.1
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.3.0
+      onetime: 6.0.0
+      signal-exit: 3.0.7
+      strip-final-newline: 3.0.0
 
   execa@8.0.1:
     dependencies:
@@ -12103,6 +12552,8 @@ snapshots:
 
   form-data-encoder@1.7.2: {}
 
+  form-data-encoder@2.1.4: {}
+
   form-data@4.0.1:
     dependencies:
       asynckit: 0.4.0
@@ -12201,6 +12652,8 @@ snapshots:
       has-proto: 1.0.3
       has-symbols: 1.0.3
       hasown: 2.0.2
+
+  get-port@3.2.0: {}
 
   get-port@6.1.2: {}
 
@@ -12355,6 +12808,20 @@ snapshots:
     dependencies:
       get-intrinsic: 1.2.4
 
+  got@12.6.1:
+    dependencies:
+      '@sindresorhus/is': 5.6.0
+      '@szmarczak/http-timer': 5.0.1
+      cacheable-lookup: 7.0.0
+      cacheable-request: 10.2.14
+      decompress-response: 6.0.0
+      form-data-encoder: 2.1.4
+      get-stream: 6.0.1
+      http2-wrapper: 2.2.1
+      lowercase-keys: 3.0.0
+      p-cancelable: 3.0.0
+      responselike: 3.0.0
+
   graceful-fs@4.2.10: {}
 
   graceful-fs@4.2.11: {}
@@ -12398,6 +12865,8 @@ snapshots:
 
   has-yarn@2.1.0: {}
 
+  has-yarn@3.0.0: {}
+
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
@@ -12424,6 +12893,13 @@ snapshots:
       wbuf: 1.7.3
 
   htmlfy@0.3.2: {}
+
+  htmlparser2@8.0.2:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      entities: 4.5.0
 
   htmlparser2@9.1.0:
     dependencies:
@@ -12480,6 +12956,11 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  http2-wrapper@2.2.1:
+    dependencies:
+      quick-lru: 5.1.1
+      resolve-alpn: 1.2.1
+
   https-proxy-agent@7.0.5:
     dependencies:
       agent-base: 7.1.1
@@ -12488,6 +12969,8 @@ snapshots:
       - supports-color
 
   human-signals@2.1.0: {}
+
+  human-signals@4.3.1: {}
 
   human-signals@5.0.0: {}
 
@@ -12553,6 +13036,8 @@ snapshots:
       resolve-from: 4.0.0
 
   import-lazy@2.1.0: {}
+
+  import-lazy@4.0.0: {}
 
   import-local@3.2.0:
     dependencies:
@@ -12655,6 +13140,10 @@ snapshots:
   is-ci@2.0.0:
     dependencies:
       ci-info: 2.0.0
+
+  is-ci@3.0.1:
+    dependencies:
+      ci-info: 3.9.0
 
   is-core-module@2.15.1:
     dependencies:
@@ -12804,6 +13293,8 @@ snapshots:
       is-inside-container: 1.0.0
 
   is-yarn-global@0.3.0: {}
+
+  is-yarn-global@0.4.1: {}
 
   is2@2.0.9:
     dependencies:
@@ -12986,6 +13477,10 @@ snapshots:
   kuler@2.0.0: {}
 
   ky@1.7.2: {}
+
+  latest-version@7.0.0:
+    dependencies:
+      package-json: 8.1.1
 
   latest-version@9.0.0:
     dependencies:
@@ -13182,6 +13677,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  lowercase-keys@3.0.0: {}
+
   lru-cache@10.4.3: {}
 
   lru-cache@11.0.2: {}
@@ -13301,6 +13798,8 @@ snapshots:
   mimic-function@5.0.1: {}
 
   mimic-response@3.1.0: {}
+
+  mimic-response@4.0.0: {}
 
   min-document@2.19.0:
     dependencies:
@@ -13506,6 +14005,8 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
+  normalize-url@8.0.1: {}
+
   npm-bundled@3.0.1:
     dependencies:
       npm-normalize-package-bin: 3.0.1
@@ -13642,6 +14143,13 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
+  open@9.1.0:
+    dependencies:
+      default-browser: 4.0.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      is-wsl: 2.2.0
+
   openai@4.70.2(encoding@0.1.13):
     dependencies:
       '@types/node': 18.19.64
@@ -13687,6 +14195,8 @@ snapshots:
       wcwidth: 1.0.1
 
   os-tmpdir@1.0.2: {}
+
+  p-cancelable@3.0.0: {}
 
   p-limit@2.3.0:
     dependencies:
@@ -13741,6 +14251,13 @@ snapshots:
   package-json@10.0.1:
     dependencies:
       ky: 1.7.2
+      registry-auth-token: 5.0.2
+      registry-url: 6.0.1
+      semver: 7.6.3
+
+  package-json@8.1.1:
+    dependencies:
+      got: 12.6.1
       registry-auth-token: 5.0.2
       registry-url: 6.0.1
       semver: 7.6.3
@@ -14093,6 +14610,8 @@ snapshots:
 
   queue-tick@1.0.1: {}
 
+  quick-lru@5.1.1: {}
+
   random-int@3.0.0: {}
 
   randombytes@2.1.0:
@@ -14297,6 +14816,8 @@ snapshots:
 
   reserve@2.0.2: {}
 
+  resolve-alpn@1.2.1: {}
+
   resolve-cwd@3.0.0:
     dependencies:
       resolve-from: 5.0.0
@@ -14312,6 +14833,10 @@ snapshots:
       is-core-module: 2.15.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  responselike@3.0.0:
+    dependencies:
+      lowercase-keys: 3.0.0
 
   resq@1.11.0:
     dependencies:
@@ -14334,6 +14859,10 @@ snapshots:
   rfdc@1.4.1: {}
 
   rgb2hex@0.2.5: {}
+
+  rimraf@2.7.1:
+    dependencies:
+      glob: 7.2.3
 
   rimraf@5.0.10:
     dependencies:
@@ -14382,6 +14911,10 @@ snapshots:
       path-to-regexp: 8.2.0
       setprototypeof: 1.2.0
       utils-merge: 1.0.1
+
+  run-applescript@5.0.0:
+    dependencies:
+      execa: 5.1.1
 
   run-applescript@7.0.0: {}
 
@@ -14438,6 +14971,10 @@ snapshots:
   semver-diff@3.1.1:
     dependencies:
       semver: 6.3.1
+
+  semver-diff@4.0.0:
+    dependencies:
+      semver: 7.6.3
 
   semver@5.7.2: {}
 
@@ -14866,6 +15403,8 @@ snapshots:
 
   tinyrainbow@1.2.0: {}
 
+  titleize@3.0.0: {}
+
   tmp@0.0.33:
     dependencies:
       os-tmpdir: 1.0.2
@@ -14938,6 +15477,8 @@ snapshots:
   type-fest@0.20.2: {}
 
   type-fest@0.21.3: {}
+
+  type-fest@1.4.0: {}
 
   type-fest@2.19.0: {}
 
@@ -15151,11 +15692,17 @@ snapshots:
     dependencies:
       crypto-random-string: 2.0.0
 
+  unique-string@3.0.0:
+    dependencies:
+      crypto-random-string: 4.0.0
+
   universalify@0.1.2: {}
 
   universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
+
+  untildify@4.0.0: {}
 
   update-browserslist-db@1.1.1(browserslist@4.24.2):
     dependencies:
@@ -15183,6 +15730,23 @@ snapshots:
       xdg-basedir: 4.0.0
     transitivePeerDependencies:
       - encoding
+
+  update-notifier@6.0.2:
+    dependencies:
+      boxen: 7.1.1
+      chalk: 5.3.0
+      configstore: 6.0.0
+      has-yarn: 3.0.0
+      import-lazy: 4.0.0
+      is-ci: 3.0.1
+      is-installed-globally: 0.4.0
+      is-npm: 6.0.0
+      is-yarn-global: 0.4.1
+      latest-version: 7.0.0
+      pupa: 3.1.0
+      semver: 7.6.3
+      semver-diff: 4.0.0
+      xdg-basedir: 5.1.0
 
   update-notifier@7.3.1:
     dependencies:
@@ -15428,6 +15992,10 @@ snapshots:
   widest-line@3.1.0:
     dependencies:
       string-width: 4.2.3
+
+  widest-line@4.0.1:
+    dependencies:
+      string-width: 5.1.2
 
   widest-line@5.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       webdriverio:
         specifier: ^9.2.8
         version: 9.2.12
+      xlsx:
+        specifier: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz
+        version: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz
 
   examples/packages/anyupload:
     dependencies:


### PR DESCRIPTION
fix #656 

- [x] Download Data (including triggering Options Dialog for Download) from the Upload Dialog
- [x] `addKeysToExport` does not show Keys when not in columns
- [x] Download Data (including triggering Options Dialog for Download) from Code (like new method in Component.ts `triggerDownload`)
- [x] Download Data (including triggering Options Dialog for Download) from XML View as Button, so as a option it renders not the button for upload but to download data
- [x] Option to display button in upload dialog or hide it (default hidden)
- [x] Complete Dev Page about Download to understand and document full process
- [x] create test (need somehow a way to check downloaded xlsx file, maybe not add it to ODataV4FE, freestyle?)
- [x] Check developer documentation how to use it
- [x] Test Flat Sheet (removed)
- [x] button in view does not respect `showOptions`
- [ ] export as CSV?
- [ ] show download sample app on the live demo
- [x] eventBeforeDownload to manipulate output

Tests:

- [x] Filename changed
  - [x]  Code
  - [x]  Dialog
- [x] `Add Keys` turned off and on
  - [x] Code
  - [x] Dialog
- [x] `Deep export` turned off and on
  - [x] Code
  - [x] Dialog
- [x] `Deep export` level change
  - [x] 0
  - [x] 1
  - [x] 2
  - [x] 3
  - [x] 1234135
  - [x] Code
  - [x] Dialog


